### PR TITLE
Refactor - Form configure/setup void return type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ test/functional/fixtures/lib/model/om/
 mockproject/
 junit.xml
 .svn
+composer.phar
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "require": {
         "php": ">=7.4",
         "composer/installers": "*",
-        "rock-symphony/propel-orm": "^2.0"
+        "rock-symphony/propel-orm": "^2.0",
+        "rock-symphony/rock-symphony": "~9.0"
     },
     "extra": {
         "branch-alias": {

--- a/data/generator/sfPropelForm/default/template/sfPropelFormBaseTemplate.php
+++ b/data/generator/sfPropelForm/default/template/sfPropelFormBaseTemplate.php
@@ -9,7 +9,7 @@
  */
 abstract class BaseFormPropel extends sfFormPropel
 {
-  public function setup()
+  public function setup(): void
   {
   }
 }

--- a/data/generator/sfPropelForm/default/template/sfPropelFormGeneratedTemplate.php
+++ b/data/generator/sfPropelForm/default/template/sfPropelFormGeneratedTemplate.php
@@ -11,7 +11,7 @@
  */
 abstract class Base<?php echo $this->table->getClassname() ?>Form extends BaseFormPropel
 {
-  public function setup()
+  public function setup(): void
   {
     $this->setWidgets(array(
 <?php foreach ($this->table->getColumns() as $column): ?>

--- a/data/generator/sfPropelForm/default/template/sfPropelFormTemplate.php
+++ b/data/generator/sfPropelForm/default/template/sfPropelFormTemplate.php
@@ -9,7 +9,7 @@
  */
 class <?php echo $this->table->getClassname() ?>Form extends Base<?php echo $this->table->getClassname() ?>Form
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/data/generator/sfPropelFormFilter/default/template/sfPropelFormFilterBaseTemplate.php
+++ b/data/generator/sfPropelFormFilter/default/template/sfPropelFormFilterBaseTemplate.php
@@ -9,7 +9,7 @@
  */
 abstract class BaseFormFilterPropel extends sfFormFilterPropel
 {
-  public function setup()
+  public function setup(): void
   {
   }
 }

--- a/data/generator/sfPropelFormFilter/default/template/sfPropelFormFilterGeneratedTemplate.php
+++ b/data/generator/sfPropelFormFilter/default/template/sfPropelFormFilterGeneratedTemplate.php
@@ -9,7 +9,7 @@
  */
 abstract class Base<?php echo $this->table->getClassname() ?>FormFilter extends BaseFormFilterPropel
 {
-  public function setup()
+  public function setup(): void
   {
     $this->setWidgets(array(
 <?php foreach ($this->table->getColumns() as $column): ?>

--- a/data/generator/sfPropelFormFilter/default/template/sfPropelFormFilterTemplate.php
+++ b/data/generator/sfPropelFormFilter/default/template/sfPropelFormFilterTemplate.php
@@ -9,7 +9,7 @@
  */
 class <?php echo $this->table->getClassname() ?>FormFilter extends Base<?php echo $this->table->getClassname() ?>FormFilter
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/doc/form.md
+++ b/doc/form.md
@@ -15,7 +15,7 @@ Most of the time, the configuration of this widget and validator is already done
 ```php
 abstract class BaseArticleForm extends BaseFormPropel
 {
-  public function setup()
+  public function setup(): void
   {
     // ...
 
@@ -47,7 +47,7 @@ You can set the widget to execute additional query methods on the related Model 
 ```php
 class ContentForm extends BaseContentForm
 {
-  public function configure()
+  public function configure(): void
   {
     $this->widgetSchema['section'] = new sfWidgetFormPropelChoice(array(
       'model'         => 'Section',
@@ -63,7 +63,7 @@ Query methods can also accept array of parameters, for example to sort branch in
 ```php
 class ContentForm extends BaseContentForm
 {
-  public function configure()
+  public function configure(): void
   {
     $this->widgetSchema['section'] = new sfWidgetFormPropelChoice(array(
       'model'         => 'Section',
@@ -78,7 +78,7 @@ You can also enable the `query_method` option on an existing widget. For instanc
 ```php
 class ArticleForm extends BaseArticleForm
 {
-  public function configure()
+  public function configure(): void
   {
     $this->widgetSchema['author_id']->setOption('query_methods', array('active'));
   }
@@ -99,7 +99,7 @@ So if you display a selection of items using a query method, you can validate th
 ```php
 class ContentForm extends BaseContentForm
 {
- public function configure()
+ public function configure(): void
  {
    $this->widgetSchema['section']->setOption('query_methods', array('published'));
    $this->validatorSchema['section']->setOption('query_methods', array('published'));
@@ -113,7 +113,7 @@ Alternatively, build the query yourself in the form, and pass it to the widget i
 ```php
 class ArticleForm extends BaseArticleForm
 {
-  public function configure()
+  public function configure(): void
   {
     $query = ArticleQuery::create()->filterByIsActive(true);
     $this->widgetSchema['author_id']->setOption('criteria', $query);
@@ -157,7 +157,7 @@ In a blog application, two articles can not have the same slug; to ensure this c
 ```php
 class ArticleForm extends BaseArticleForm
 {
-  public function configure()
+  public function configure(): void
   {
     // ...
 
@@ -193,7 +193,7 @@ Here is an example for `created_at` and `updated_at` columns, that you may want 
 ```php
 class ArticleForm extends BaseArticleForm
 {
-  public function configure()
+  public function configure(): void
   {
     // ...
     $this->setWidget('created_at', new sfWidgetFormPlain());
@@ -238,7 +238,7 @@ Since one-to-many relationships return `PropelCollection` objects, the ability t
 ```php
 class ArticleForm extends BaseArticleForm
 {
-  public function configure()
+  public function configure(): void
   {
     $this->embedRelation('Book');
   }

--- a/lib/form/sfFormPropelCollection.class.php
+++ b/lib/form/sfFormPropelCollection.class.php
@@ -71,7 +71,7 @@ class sfFormPropelCollection extends sfForm
   /**
    * Configures the current form.
    */
-  public function configure()
+  public function configure(): void
   {
     $formClass = $this->getFormClass();
     $i = 1;

--- a/test/functional/fixtures/apps/backend_compat/config/backend_compatConfiguration.class.php
+++ b/test/functional/fixtures/apps/backend_compat/config/backend_compatConfiguration.class.php
@@ -2,7 +2,7 @@
 
 class backend_compatConfiguration extends sfApplicationConfiguration
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/apps/crud/config/crudConfiguration.class.php
+++ b/test/functional/fixtures/apps/crud/config/crudConfiguration.class.php
@@ -2,7 +2,7 @@
 
 class crudConfiguration extends sfApplicationConfiguration
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/apps/frontend/config/frontendConfiguration.class.php
+++ b/test/functional/fixtures/apps/frontend/config/frontendConfiguration.class.php
@@ -2,7 +2,7 @@
 
 class frontendConfiguration extends sfApplicationConfiguration
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/filter/ArticleFormFilter.class.php
+++ b/test/functional/fixtures/lib/filter/ArticleFormFilter.class.php
@@ -10,7 +10,7 @@
  */
 class ArticleFormFilter extends BaseArticleFormFilter
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/filter/AttachmentFormFilter.class.php
+++ b/test/functional/fixtures/lib/filter/AttachmentFormFilter.class.php
@@ -10,7 +10,7 @@
  */
 class AttachmentFormFilter extends BaseAttachmentFormFilter
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/filter/AuthorFormFilter.class.php
+++ b/test/functional/fixtures/lib/filter/AuthorFormFilter.class.php
@@ -10,7 +10,7 @@
  */
 class AuthorFormFilter extends BaseAuthorFormFilter
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/filter/BaseFormFilterPropel.class.php
+++ b/test/functional/fixtures/lib/filter/BaseFormFilterPropel.class.php
@@ -10,7 +10,7 @@
  */
 abstract class BaseFormFilterPropel extends sfFormFilterPropel
 {
-  public function setup()
+  public function setup(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/filter/BookFormFilter.class.php
+++ b/test/functional/fixtures/lib/filter/BookFormFilter.class.php
@@ -10,7 +10,7 @@
  */
 class BookFormFilter extends BaseBookFormFilter
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/filter/CategoryFormFilter.class.php
+++ b/test/functional/fixtures/lib/filter/CategoryFormFilter.class.php
@@ -10,7 +10,7 @@
  */
 class CategoryFormFilter extends BaseCategoryFormFilter
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/filter/MovieFormFilter.class.php
+++ b/test/functional/fixtures/lib/filter/MovieFormFilter.class.php
@@ -10,7 +10,7 @@
  */
 class MovieFormFilter extends BaseMovieFormFilter
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/filter/MovieI18nFormFilter.class.php
+++ b/test/functional/fixtures/lib/filter/MovieI18nFormFilter.class.php
@@ -10,7 +10,7 @@
  */
 class MovieI18nFormFilter extends BaseMovieI18nFormFilter
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/filter/ProductFormFilter.class.php
+++ b/test/functional/fixtures/lib/filter/ProductFormFilter.class.php
@@ -10,7 +10,7 @@
  */
 class ProductFormFilter extends BaseProductFormFilter
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/filter/ProductI18nFormFilter.class.php
+++ b/test/functional/fixtures/lib/filter/ProductI18nFormFilter.class.php
@@ -10,7 +10,7 @@
  */
 class ProductI18nFormFilter extends BaseProductI18nFormFilter
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/filter/ToyFormFilter.class.php
+++ b/test/functional/fixtures/lib/filter/ToyFormFilter.class.php
@@ -9,7 +9,7 @@
  */
 class ToyFormFilter extends BaseToyFormFilter
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/filter/ToyI18nFormFilter.class.php
+++ b/test/functional/fixtures/lib/filter/ToyI18nFormFilter.class.php
@@ -9,7 +9,7 @@
  */
 class ToyI18nFormFilter extends BaseToyI18nFormFilter
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/form/ArticleForm.class.php
+++ b/test/functional/fixtures/lib/form/ArticleForm.class.php
@@ -9,7 +9,7 @@
  */
 class ArticleForm extends BaseArticleForm
 {
-  public function configure()
+  public function configure(): void
   {
     if ($category = $this->getObject()->getCategory())
     {

--- a/test/functional/fixtures/lib/form/AttachmentForm.class.php
+++ b/test/functional/fixtures/lib/form/AttachmentForm.class.php
@@ -9,7 +9,7 @@
  */
 class AttachmentForm extends BaseAttachmentForm
 {
-  public function configure()
+  public function configure(): void
   {
     $this->widgetSchema['file'] = new sfWidgetFormInputFile();
     $this->validatorSchema['file'] = new sfValidatorFile(array(

--- a/test/functional/fixtures/lib/form/AuthorForm.class.php
+++ b/test/functional/fixtures/lib/form/AuthorForm.class.php
@@ -9,7 +9,7 @@
  */
 class AuthorForm extends BaseAuthorForm
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/form/BaseFormPropel.class.php
+++ b/test/functional/fixtures/lib/form/BaseFormPropel.class.php
@@ -8,7 +8,7 @@
  */
 abstract class BaseFormPropel extends sfFormPropel
 {
-  public function setup()
+  public function setup(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/form/BookForm.class.php
+++ b/test/functional/fixtures/lib/form/BookForm.class.php
@@ -9,7 +9,7 @@
  */
 class BookForm extends BaseBookForm
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/form/CategoryForm.class.php
+++ b/test/functional/fixtures/lib/form/CategoryForm.class.php
@@ -9,7 +9,7 @@
  */
 class CategoryForm extends BaseCategoryForm
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/form/MovieForm.class.php
+++ b/test/functional/fixtures/lib/form/MovieForm.class.php
@@ -9,7 +9,7 @@
  */
 class MovieForm extends BaseMovieForm
 {
-  public function configure()
+  public function configure(): void
   {
     $this->embedI18n(array('en', 'fr'));
     $this->embedRelation('Toy');

--- a/test/functional/fixtures/lib/form/MovieI18nForm.class.php
+++ b/test/functional/fixtures/lib/form/MovieI18nForm.class.php
@@ -9,7 +9,7 @@
  */
 class MovieI18nForm extends BaseMovieI18nForm
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/form/MoviePropelForm.class.php
+++ b/test/functional/fixtures/lib/form/MoviePropelForm.class.php
@@ -9,7 +9,7 @@
  */
 class MoviePropelForm extends BaseMoviePropelForm
 {
-  public function configure()
+  public function configure(): void
   {
     $this->embedI18n(array('en', 'fr'));
     $this->embedRelation('ToyPropel');

--- a/test/functional/fixtures/lib/form/MoviePropelI18nForm.class.php
+++ b/test/functional/fixtures/lib/form/MoviePropelI18nForm.class.php
@@ -9,7 +9,7 @@
  */
 class MoviePropelI18nForm extends BaseMoviePropelI18nForm
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/form/ProductForm.class.php
+++ b/test/functional/fixtures/lib/form/ProductForm.class.php
@@ -9,7 +9,7 @@
  */
 class ProductForm extends BaseProductForm
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/form/ProductI18nForm.class.php
+++ b/test/functional/fixtures/lib/form/ProductI18nForm.class.php
@@ -9,7 +9,7 @@
  */
 class ProductI18nForm extends BaseProductI18nForm
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/form/ToyForm.class.php
+++ b/test/functional/fixtures/lib/form/ToyForm.class.php
@@ -9,7 +9,7 @@
  */
 class ToyForm extends BaseToyForm
 {
-  public function configure()
+  public function configure(): void
   {
     $this->embedI18n(array('fr', 'en'));
   }

--- a/test/functional/fixtures/lib/form/ToyI18nForm.class.php
+++ b/test/functional/fixtures/lib/form/ToyI18nForm.class.php
@@ -9,7 +9,7 @@
  */
 class ToyI18nForm extends BaseToyI18nForm
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/functional/fixtures/lib/form/ToyPropelForm.class.php
+++ b/test/functional/fixtures/lib/form/ToyPropelForm.class.php
@@ -9,7 +9,7 @@
  */
 class ToyPropelForm extends BaseToyPropelForm
 {
-  public function configure()
+  public function configure(): void
   {
     $this->embedI18n(array('fr', 'en'));
   }

--- a/test/functional/fixtures/lib/form/ToyPropelI18nForm.class.php
+++ b/test/functional/fixtures/lib/form/ToyPropelI18nForm.class.php
@@ -9,7 +9,7 @@
  */
 class ToyPropelI18nForm extends BaseToyPropelI18nForm
 {
-  public function configure()
+  public function configure(): void
   {
   }
 }

--- a/test/unit/sfFormFilterPropelTest.php
+++ b/test/unit/sfFormFilterPropelTest.php
@@ -93,7 +93,7 @@ abstract class MockFilter extends sfFormFilterPropel {
 }
 class MockFilterMerged extends MockFilter
 {
-  public function configure()
+  public function configure(): void
   {
     $this->setValidators(array(
       'merged_filter'   => new sfValidatorPass(array('required' => false)),
@@ -112,7 +112,7 @@ class MockFilterMerged extends MockFilter
 }
 class MockFilterEmbedded extends MockFilter
 {
-  public function configure()
+  public function configure(): void
   {
     $this->setValidators(array(
       'embedded_filter'   => new sfValidatorPass(array('required' => false)),
@@ -133,7 +133,7 @@ class MockModelFilter extends MockFilter
 {
   public function getModelName() { return 'MockModel'; }
 
-  public function configure()
+  public function configure(): void
   {
     $this->setValidators(array(
       'my_filter'   => new sfValidatorPass(array('required' => false)),


### PR DESCRIPTION
See https://github.com/rock-symphony/rock-symphony/pull/46

- Update generated forms code to also have native `:void` return type on `sfForm::setup()` and `sfForm::configure()` overrides
