### PR TITLE
Feature - Reimplement migrations mechanism

### DIFF
--- a/lib/task/sfPropelDiffTask.class.php
+++ b/lib/task/sfPropelDiffTask.class.php
@@ -27,7 +27,7 @@ class sfPropelDiffTask extends sfPropelBaseTask
       new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
       new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
       new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
-      new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'propel_migration'),
+      new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'migration'),
       new sfCommandOption('editor-cmd', null, sfCommandOption::PARAMETER_OPTIONAL, 'A command used to edit the migration class'),
       new sfCommandOption('ask-confirmation', null, sfCommandOption::PARAMETER_NONE, 'Ask for confirmation'),
       new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),

--- a/lib/task/sfPropelDiffTask.class.php
+++ b/lib/task/sfPropelDiffTask.class.php
@@ -27,7 +27,7 @@ class sfPropelDiffTask extends sfPropelBaseTask
       new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
       new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
       new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
-      new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'migration'),
+      new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'propel_migration'),
       new sfCommandOption('editor-cmd', null, sfCommandOption::PARAMETER_OPTIONAL, 'A command used to edit the migration class'),
       new sfCommandOption('ask-confirmation', null, sfCommandOption::PARAMETER_NONE, 'Ask for confirmation'),
       new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),

--- a/lib/task/sfPropelDiffTask.class.php
+++ b/lib/task/sfPropelDiffTask.class.php
@@ -124,7 +124,7 @@ EOF;
     }
 
     $this->logSection('propel', 'Comparing databases and schemas...');
-    $manager = new PropelMigrationManager();
+    $manager = new sfPropelMigrationManager();
     $manager->setConnections($connections);
     $migrationsUp = array();
     $migrationsDown = array();
@@ -166,7 +166,7 @@ EOF;
 
     $timestamp = time();
     $migrationDirectory = sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir'];
-    $migrationFileName = $manager->getMigrationFileName($timestamp);
+    $migrationFileName = $manager->generateMigrationFileName($timestamp);
     $migrationFilePath = $migrationDirectory . DIRECTORY_SEPARATOR . $migrationFileName;
     if (
       $options['ask-confirmation']
@@ -180,7 +180,7 @@ EOF;
       return 1;
     }
     $this->getFilesystem()->mkdirs($migrationDirectory);
-    $migrationClassBody = $manager->getMigrationClassBody($migrationsUp, $migrationsDown, $timestamp);
+    $migrationClassBody = $manager->generateMigrationClassBody($migrationsUp, $migrationsDown, $timestamp);
     file_put_contents($migrationFilePath, $migrationClassBody);
     $this->logSection('propel', sprintf('"%s" file successfully created in %s', $migrationFileName, $migrationDirectory));
 

--- a/lib/task/sfPropelMigrateDownTask.class.php
+++ b/lib/task/sfPropelMigrateDownTask.class.php
@@ -30,7 +30,7 @@ class sfPropelMigrateDownTask extends sfPropelBaseTask
             new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
             new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
             new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
-            new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'migration'),
+            new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'propel_migration'),
             new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
         ));
         $this->namespace = 'propel';

--- a/lib/task/sfPropelMigrateDownTask.class.php
+++ b/lib/task/sfPropelMigrateDownTask.class.php
@@ -61,6 +61,7 @@ EOF;
         $manager->setMigrationDir($migrationDirectory);
 
         $migrationName = $manager->getLatestExecutedMigrationName();
+
         if (empty($migrationName))
         {
             $this->logSection('propel', 'No migration were ever executed on this database - nothing to reverse.');
@@ -101,7 +102,7 @@ EOF;
                     // continue
                 }
             }
-            if (! $res) {
+            if (!$res) {
                 $this->logSection('propel', sprintf(
                     'Please review the code in "%s"',
                     $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $migrationName

--- a/lib/task/sfPropelMigrateDownTask.class.php
+++ b/lib/task/sfPropelMigrateDownTask.class.php
@@ -18,140 +18,123 @@
  */
 class sfPropelMigrateDownTask extends sfPropelBaseTask
 {
-  private const OK = 0;
-  private const NOT_OK = 1;
+    private const OK = 0;
+    private const NOT_OK = 1;
 
-  /**
-   * @see sfTask
-   */
-  protected function configure()
-  {
-    $this->addOptions(array(
-      new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
-      new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
-      new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
-      new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'propel_migration'),
-      new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
-    ));
-    $this->namespace = 'propel';
-    $this->name = 'down';
-    $this->aliases = array('migration-down');
-    $this->briefDescription = 'Executes the next migration down';
+    /**
+     * @see sfTask
+     */
+    protected function configure()
+    {
+        $this->addOptions(array(
+            new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
+            new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
+            new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
+            new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'migration'),
+            new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
+        ));
+        $this->namespace = 'propel';
+        $this->name = 'down';
+        $this->aliases = array('migration-down');
+        $this->briefDescription = 'Executes the next migration down';
 
-    $this->detailedDescription = <<<EOF
+        $this->detailedDescription = <<<EOF
 The [propel:up|INFO] checks the version of the database structure, and looks for migration files already executed (i.e. with a lower version timestamp). The last executed migration found is reversed.
 
 The task reads the database connection settings in [config/databases.yml|COMMENT].
 
 The task looks for migration classes in [lib/model/migration|COMMENT].
 EOF;
-  }
-
-  /**
-   * @see sfTask
-   */
-  protected function execute($arguments = array(), $options = array())
-  {
-    $databaseManager = new sfDatabaseManager($this->configuration);
-    $connections = $this->getConnections($databaseManager);
-    $manager = new PropelMigrationManager();
-    $manager->setConnections($connections);
-    $manager->setMigrationTable($options['migration-table']);
-    $migrationDirectory = sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir'];
-    $manager->setMigrationDir($migrationDirectory);
-
-    $previousTimestamps = $manager->getAlreadyExecutedMigrationTimestamps();
-    if (!$nextMigrationTimestamp = array_pop($previousTimestamps))
-    {
-      $this->logSection('propel', 'No migration were ever executed on this database - nothing to reverse.');
-      return self::OK;
-    }
-    $this->logSection('propel', sprintf(
-      'Executing migration %s down',
-      $manager->getMigrationClassName($nextMigrationTimestamp)
-    ));
-
-    if ($nbPreviousTimestamps = count($previousTimestamps))
-    {
-      $previousTimestamp = array_pop($previousTimestamps);
-    }
-    else
-    {
-      $previousTimestamp = 0;
     }
 
-    $migration = $manager->getMigrationObject($nextMigrationTimestamp);
-    if (false === $migration->preDown($manager))
+    /**
+     * @see sfTask
+     */
+    protected function execute($arguments = array(), $options = array())
     {
-      $this->logSection('propel', 'preDown() returned false. Aborting migration.', null, 'ERROR');
-      return self::NOT_OK;
-    }
+        $databaseManager = new sfDatabaseManager($this->configuration);
+        $connections = $this->getConnections($databaseManager);
+        $manager = new sfPropelMigrationManager();
+        $manager->setConnections($connections);
+        $manager->setMigrationTable($options['migration-table']);
+        $migrationDirectory = sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir'];
+        $manager->setMigrationDir($migrationDirectory);
 
-    foreach ($migration->getDownSQL() as $datasource => $sql)
-    {
-      $connection = $manager->getConnection($datasource);
-      if ($options['verbose'])
-      {
-        $this->logSection('propel', sprintf('  Connecting to database "%s" using DSN "%s"', $datasource, $connection['dsn']), null, 'COMMENT');
-      }
-      $pdo = $manager->getPdoConnection($datasource);
-      $res = 0;
-      $statements = PropelSQLParser::parseString($sql);
-      foreach ($statements as $statement)
-      {
-        try
+        $latestExecutedMigrations = $manager->getExecutedMigrationNamesForBatch($manager->getLatestBatch());
+        if (empty($latestExecutedMigrations))
         {
-          if ($options['verbose'])
-          {
-            $this->logSection('propel', sprintf('  Executing statement "%s"', $statement), null, 'COMMENT');
-          }
-          $stmt = $pdo->prepare($statement);
-          $stmt->execute();
-          $res++;
+            $this->logSection('propel', 'No migration were ever executed on this database - nothing to reverse.');
+            return self::OK;
         }
-        catch (PDOException $e)
-        {
-          $this->logSection(sprintf('Failed to execute SQL "%s". Aborting migration.', $statement), null, 'ERROR');
-          return self::NOT_OK;
-          // continue
+        $this->logSection('propel', 'Executing migrations down');
+
+        foreach ($latestExecutedMigrations as $migrationName) {
+            $migration = $manager->getMigrationObject($migrationName);
+            if (false === $migration->preDown($manager)) {
+                $this->logSection('propel', 'preDown() returned false. Aborting migration.', null, 'ERROR');
+
+                return self::NOT_OK;
+            }
+
+            foreach ($migration->getDownSQL() as $datasource => $sql) {
+                $connection = $manager->getConnection($datasource);
+                if ($options['verbose']) {
+                    $this->logSection('propel',
+                        sprintf('  Connecting to database "%s" using DSN "%s"', $datasource, $connection['dsn']), null,
+                        'COMMENT');
+                }
+                $pdo = $manager->getPdoConnection($datasource);
+                $res = 0;
+                $statements = PropelSQLParser::parseString($sql);
+                foreach ($statements as $statement) {
+                    try {
+                        if ($options['verbose']) {
+                            $this->logSection('propel', sprintf('  Executing statement "%s"', $statement), null, 'COMMENT');
+                        }
+                        $stmt = $pdo->prepare($statement);
+                        $stmt->execute();
+                        $res++;
+                    } catch (PDOException $e) {
+                        $this->logSection(sprintf('Failed to execute SQL "%s". Aborting migration.', $statement), null,
+                            'ERROR');
+
+                        return self::NOT_OK;
+                        // continue
+                    }
+                }
+                if (! $res) {
+                    $this->logSection('propel', sprintf(
+                        'Please review the code in "%s"',
+                        $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $migrationName
+                    ));
+                    $this->logSection('propel', 'Migration aborted', null, 'ERROR');
+
+                    return self::NOT_OK;
+                }
+                $this->logSection('propel', sprintf(
+                    '%d of %d SQL statements executed successfully on datasource "%s"',
+                    $res,
+                    count($statements),
+                    $datasource
+                ));
+
+                $manager->removeExecutedMigration($datasource, $migrationName);
+                if ($options['verbose']) {
+                    $this->logSection(
+                        'propel',
+                        sprintf('  Removed %s from executed migrations for datasource "%s"', $migrationName, $datasource),
+                        null,
+                        'COMMENT'
+                    );
+                }
+            }
+
+            $migration->postDown($manager);
         }
-      }
-      if (!$res)
-      {
-        $this->logSection('propel', 'No statement was executed. The version was not updated.');
-        $this->logSection('propel', sprintf(
-          'Please review the code in "%s"',
-          $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $manager->getMigrationClassName($nextMigrationTimestamp)
-        ));
-        $this->logSection('propel', 'Migration aborted', null, 'ERROR');
-        return self::NOT_OK;
-      }
-      $this->logSection('propel', sprintf(
-        '%d of %d SQL statements executed successfully on datasource "%s"',
-        $res,
-        count($statements),
-        $datasource
-      ));
 
-      $manager->updateLatestMigrationTimestamp($datasource, $previousTimestamp);
-      if ($options['verbose'])
-      {
-        $this->logSection('propel', sprintf('  Downgraded latest migration date to %d for datasource "%s"', $previousTimestamp, $datasource), null, 'COMMENT');
-      }
+        $this->logSection('propel', sprintf('Reverse migration complete. %d migrations were rolled back.', count($latestExecutedMigrations)));
+
+        return self::OK;
     }
-
-    $migration->postDown($manager);
-
-    if ($nbPreviousTimestamps)
-    {
-      $this->logSection('propel', sprintf('Reverse migration complete. %d more migrations available for reverse.', $nbPreviousTimestamps));
-    }
-    else
-    {
-      $this->logSection('propel', 'Reverse migration complete. No more migration available for reverse');
-    }
-
-    return self::OK;
-  }
 
 }

--- a/lib/task/sfPropelMigrateDownTask.class.php
+++ b/lib/task/sfPropelMigrateDownTask.class.php
@@ -18,122 +18,121 @@
  */
 class sfPropelMigrateDownTask extends sfPropelBaseTask
 {
-    private const OK = 0;
-    private const NOT_OK = 1;
+  private const OK = 0;
+  private const NOT_OK = 1;
 
-    /**
-     * @see sfTask
-     */
-    protected function configure()
-    {
-        $this->addOptions(array(
-            new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
-            new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
-            new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
-            new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'propel_migration'),
-            new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
-        ));
-        $this->namespace = 'propel';
-        $this->name = 'down';
-        $this->aliases = array('migration-down');
-        $this->briefDescription = 'Executes the next migration down';
+  /**
+   * @see sfTask
+   */
+  protected function configure()
+  {
+    $this->addOptions(array(
+      new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
+      new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
+      new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
+      new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'propel_migration'),
+      new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
+    ));
+    $this->namespace = 'propel';
+    $this->name = 'down';
+    $this->aliases = array('migration-down');
+    $this->briefDescription = 'Executes the next migration down';
 
-        $this->detailedDescription = <<<EOF
+    $this->detailedDescription = <<<EOF
 The [propel:up|INFO] checks the version of the database structure, and looks for migration files already executed (i.e. with a lower version timestamp). The last executed migration found is reversed.
 
 The task reads the database connection settings in [config/databases.yml|COMMENT].
 
 The task looks for migration classes in [lib/model/migration|COMMENT].
 EOF;
+  }
+
+  /**
+   * @see sfTask
+   */
+  protected function execute($arguments = array(), $options = array())
+  {
+    $databaseManager = new sfDatabaseManager($this->configuration);
+    $connections = $this->getConnections($databaseManager);
+    $manager = new sfPropelMigrationManager();
+    $manager->setConnections($connections);
+    $manager->setMigrationDir(sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir']);
+    $manager->setMigrationTable($options['migration-table']);
+
+    $migrationName = $manager->getLatestExecutedMigrationName();
+
+    if (empty($migrationName)) {
+      $this->logSection('propel', 'No migration were ever executed on this database - nothing to reverse.');
+      return self::OK;
+    }
+    $this->logSection('propel', 'Executing migrations down');
+
+    $migration = $manager->getMigrationObject($migrationName);
+    if (false === $migration->preDown($manager)) {
+      $this->logSection('propel', 'preDown() returned false. Aborting migration.', null, 'ERROR');
+
+      return self::NOT_OK;
     }
 
-    /**
-     * @see sfTask
-     */
-    protected function execute($arguments = array(), $options = array())
-    {
-        $databaseManager = new sfDatabaseManager($this->configuration);
-        $connections = $this->getConnections($databaseManager);
-        $manager = new sfPropelMigrationManager();
-        $manager->setConnections($connections);
-        $manager->setMigrationDir(sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir']);
-        $manager->setMigrationTable($options['migration-table']);
+    foreach ($migration->getDownSQL() as $datasource => $sql) {
+      $connection = $manager->getConnection($datasource);
+      if ($options['verbose']) {
+        $this->logSection('propel',
+          sprintf('  Connecting to database "%s" using DSN "%s"', $datasource, $connection['dsn']), null,
+          'COMMENT');
+      }
+      $pdo = $manager->getPdoConnection($datasource);
+      $res = 0;
+      $statements = PropelSQLParser::parseString($sql);
+      foreach ($statements as $statement) {
+        try {
+          if ($options['verbose']) {
+            $this->logSection('propel', sprintf('  Executing statement "%s"', $statement), null, 'COMMENT');
+          }
+          $stmt = $pdo->prepare($statement);
+          $stmt->execute();
+          $res++;
+        } catch (PDOException $e) {
+          $this->logSection(sprintf('Failed to execute SQL "%s". Aborting migration.', $statement), null,
+            'ERROR');
 
-        $migrationName = $manager->getLatestExecutedMigrationName();
-
-        if (empty($migrationName))
-        {
-            $this->logSection('propel', 'No migration were ever executed on this database - nothing to reverse.');
-            return self::OK;
+          return self::NOT_OK;
+          // continue
         }
-        $this->logSection('propel', 'Executing migrations down');
+      }
+      if (!$res) {
+        $this->logSection('propel', sprintf(
+          'Please review the code in "%s"',
+          $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $migrationName
+        ));
+        $this->logSection('propel', 'Migration aborted', null, 'ERROR');
 
-        $migration = $manager->getMigrationObject($migrationName);
-        if (false === $migration->preDown($manager)) {
-            $this->logSection('propel', 'preDown() returned false. Aborting migration.', null, 'ERROR');
-
-            return self::NOT_OK;
-        }
-
-        foreach ($migration->getDownSQL() as $datasource => $sql) {
-            $connection = $manager->getConnection($datasource);
-            if ($options['verbose']) {
-                $this->logSection('propel',
-                    sprintf('  Connecting to database "%s" using DSN "%s"', $datasource, $connection['dsn']), null,
-                    'COMMENT');
-            }
-            $pdo = $manager->getPdoConnection($datasource);
-            $res = 0;
-            $statements = PropelSQLParser::parseString($sql);
-            foreach ($statements as $statement) {
-                try {
-                    if ($options['verbose']) {
-                        $this->logSection('propel', sprintf('  Executing statement "%s"', $statement), null, 'COMMENT');
-                    }
-                    $stmt = $pdo->prepare($statement);
-                    $stmt->execute();
-                    $res++;
-                } catch (PDOException $e) {
-                    $this->logSection(sprintf('Failed to execute SQL "%s". Aborting migration.', $statement), null,
-                        'ERROR');
-
-                    return self::NOT_OK;
-                    // continue
-                }
-            }
-            if (!$res) {
-                $this->logSection('propel', sprintf(
-                    'Please review the code in "%s"',
-                    $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $migrationName
-                ));
-                $this->logSection('propel', 'Migration aborted', null, 'ERROR');
-
-                return self::NOT_OK;
-            }
-            $this->logSection('propel', sprintf(
-                '%d of %d SQL statements executed successfully on datasource "%s"',
-                $res,
-                count($statements),
-                $datasource
-            ));
-        }
-
-        $manager->removeExecutedMigration($migrationName);
-
-        if ($options['verbose']) {
-            $this->logSection(
-                'propel',
-                sprintf('  Removed %s from executed migrations', $migrationName),
-                null,
-                'COMMENT'
-            );
-        }
-
-        $migration->postDown($manager);
-
-        $this->logSection('propel', sprintf('Reverse migration complete. %s is rolled back.', $migrationName));
-
-        return self::OK;
+        return self::NOT_OK;
+      }
+      $this->logSection('propel', sprintf(
+        '%d of %d SQL statements executed successfully on datasource "%s"',
+        $res,
+        count($statements),
+        $datasource
+      ));
     }
+
+    $manager->removeExecutedMigration($migrationName);
+
+    if ($options['verbose']) {
+      $this->logSection(
+        'propel',
+        sprintf('  Removed %s from executed migrations', $migrationName),
+        null,
+        'COMMENT'
+      );
+    }
+
+    $migration->postDown($manager);
+
+    $this->logSection('propel', sprintf('Reverse migration complete. %s is rolled back.', $migrationName));
+
+    return self::OK;
+  }
 
 }

--- a/lib/task/sfPropelMigrateDownTask.class.php
+++ b/lib/task/sfPropelMigrateDownTask.class.php
@@ -56,9 +56,8 @@ EOF;
         $connections = $this->getConnections($databaseManager);
         $manager = new sfPropelMigrationManager();
         $manager->setConnections($connections);
+        $manager->setMigrationDir(sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir']);
         $manager->setMigrationTable($options['migration-table']);
-        $migrationDirectory = sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir'];
-        $manager->setMigrationDir($migrationDirectory);
 
         $migrationName = $manager->getLatestExecutedMigrationName();
 
@@ -117,16 +116,17 @@ EOF;
                 count($statements),
                 $datasource
             ));
+        }
 
-            $manager->removeExecutedMigration($datasource, $migrationName);
-            if ($options['verbose']) {
-                $this->logSection(
-                    'propel',
-                    sprintf('  Removed %s from executed migrations for datasource "%s"', $migrationName, $datasource),
-                    null,
-                    'COMMENT'
-                );
-            }
+        $manager->removeExecutedMigration($migrationName);
+
+        if ($options['verbose']) {
+            $this->logSection(
+                'propel',
+                sprintf('  Removed %s from executed migrations', $migrationName),
+                null,
+                'COMMENT'
+            );
         }
 
         $migration->postDown($manager);

--- a/lib/task/sfPropelMigrateTask.class.php
+++ b/lib/task/sfPropelMigrateTask.class.php
@@ -18,133 +18,120 @@
  */
 class sfPropelMigrateTask extends sfPropelBaseTask
 {
-    private const OK = 0;
-    private const NOT_OK = 1;
+  private const OK = 0;
+  private const NOT_OK = 1;
 
-    /**
-     * @see sfTask
-     */
-    protected function configure()
-    {
-        $this->addOptions(array(
-            new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
-            new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
-            new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
-            new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'propel_migration'),
-            new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
-        ));
-        $this->namespace = 'propel';
-        $this->name = 'migrate';
-        $this->aliases = array('migration-all');
-        $this->briefDescription = 'Executes the next migrations up';
+  /**
+   * @see sfTask
+   */
+  protected function configure()
+  {
+    $this->addOptions(array(
+      new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
+      new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
+      new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
+      new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'propel_migration'),
+      new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
+    ));
+    $this->namespace = 'propel';
+    $this->name = 'migrate';
+    $this->aliases = array('migration-all');
+    $this->briefDescription = 'Executes the next migrations up';
 
-        $this->detailedDescription = <<<EOF
+    $this->detailedDescription = <<<EOF
 The [propel:up|INFO] checks the version of the database structure, looks for migration files not yet executed (i.e. with a greater version timestamp), and executes them.
 
 The task reads the database connection settings in [config/databases.yml|COMMENT].
 
 The task looks for migration classes in [lib/model/migration|COMMENT].
 EOF;
+  }
+
+  /**
+   * @see sfTask
+   */
+  protected function execute($arguments = array(), $options = array())
+  {
+    $databaseManager = new sfDatabaseManager($this->configuration);
+    $connections = $this->getConnections($databaseManager);
+    $manager = new sfPropelMigrationManager();
+    $manager->setConnections($connections);
+    $manager->setMigrationDir(sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir']);
+    $manager->setMigrationTable($options['migration-table']);
+
+    $missingMigrations = $manager->getMissingMigrationNames();
+
+    if (empty($missingMigrations)) {
+      $this->logSection('propel', 'All migrations were already executed - nothing to migrate.');
+      return self::OK;
     }
 
-    /**
-     * @see sfTask
-     */
-    protected function execute($arguments = array(), $options = array())
-    {
-        $databaseManager = new sfDatabaseManager($this->configuration);
-        $connections = $this->getConnections($databaseManager);
-        $manager = new sfPropelMigrationManager();
-        $manager->setConnections($connections);
-        $manager->setMigrationDir(sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir']);
-        $manager->setMigrationTable($options['migration-table']);
-
-        $missingMigrations = $manager->getMissingMigrationNames();
-
-        if (empty($missingMigrations))
-        {
-            $this->logSection('propel', 'All migrations were already executed - nothing to migrate.');
-            return self::OK;
-        }
-
-        if (count($missingMigrations) > 1)
-        {
-            $this->logSection('propel', sprintf('%d migrations to execute', count($missingMigrations)));
-        }
-
-        foreach ($missingMigrations as $migrationName)
-        {
-            $this->logSection('propel', sprintf(
-                'Executing migration %s up',
-                $migrationName
-            ));
-
-            $migration = $manager->getMigrationObject($migrationName);
-
-            if (false === $migration->preUp($manager))
-            {
-                $this->logSection('propel', 'preUp() returned false. Aborting migration.', null, 'ERROR');
-                return self::NOT_OK;
-            }
-
-            foreach ($migration->getUpSQL() as $datasource => $sql)
-            {
-                $connection = $manager->getConnection($datasource);
-                if ($options['verbose'])
-                {
-                    $this->logSection('propel', sprintf('  Connecting to database "%s" using DSN "%s"', $datasource, $connection['dsn']), null, 'COMMENT');
-                }
-                $pdo = $manager->getPdoConnection($datasource);
-                $res = self::OK;
-                $statements = PropelSQLParser::parseString($sql);
-                foreach ($statements as $statement)
-                {
-                    try
-                    {
-                        if ($options['verbose'])
-                        {
-                            $this->logSection('propel', sprintf('  Executing statement "%s"', $statement), null, 'COMMENT');
-                        }
-                        $stmt = $pdo->prepare($statement);
-                        $stmt->execute();
-                        $res++;
-                    }
-                    catch (PDOException $e)
-                    {
-                        $this->logSection(sprintf('Failed to execute SQL "%s". Aborting migration.', $statement), null, 'ERROR');
-                        return self::NOT_OK;
-                    }
-                }
-                if (!$res)
-                {
-                    $this->logSection('propel', sprintf(
-                        'Please review the code in "%s"',
-                        $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $migrationName
-                    ));
-                    $this->logSection('propel', 'Migration aborted', null, 'ERROR');
-                    return self::NOT_OK;
-                }
-                $this->logSection('propel', sprintf(
-                    '%d of %d SQL statements executed successfully on datasource "%s"',
-                    $res,
-                    count($statements),
-                    $datasource
-                ));
-            }
-
-            $manager->addExecutedMigration($migrationName);
-
-            if ($options['verbose'])
-            {
-                $this->logSection('propel', sprintf('  Added %s to executed migrations', $migrationName), null, 'COMMENT');
-            }
-
-            $migration->postUp($manager);
-        }
-
-        $this->logSection('propel', 'Migration complete. No further migration to execute.');
-
-        return self::OK;
+    if (count($missingMigrations) > 1) {
+      $this->logSection('propel', sprintf('%d migrations to execute', count($missingMigrations)));
     }
+
+    foreach ($missingMigrations as $migrationName) {
+      $this->logSection('propel', sprintf(
+        'Executing migration %s up',
+        $migrationName
+      ));
+
+      $migration = $manager->getMigrationObject($migrationName);
+
+      if (false === $migration->preUp($manager)) {
+        $this->logSection('propel', 'preUp() returned false. Aborting migration.', null, 'ERROR');
+        return self::NOT_OK;
+      }
+
+      foreach ($migration->getUpSQL() as $datasource => $sql) {
+        $connection = $manager->getConnection($datasource);
+        if ($options['verbose']) {
+          $this->logSection('propel', sprintf('  Connecting to database "%s" using DSN "%s"', $datasource, $connection['dsn']), null, 'COMMENT');
+        }
+        $pdo = $manager->getPdoConnection($datasource);
+        $res = self::OK;
+        $statements = PropelSQLParser::parseString($sql);
+        foreach ($statements as $statement) {
+          try {
+            if ($options['verbose']) {
+              $this->logSection('propel', sprintf('  Executing statement "%s"', $statement), null, 'COMMENT');
+            }
+            $stmt = $pdo->prepare($statement);
+            $stmt->execute();
+            $res++;
+          } catch (PDOException $e) {
+            $this->logSection(sprintf('Failed to execute SQL "%s". Aborting migration.', $statement), null, 'ERROR');
+            return self::NOT_OK;
+          }
+        }
+        if (!$res) {
+          $this->logSection('propel', sprintf(
+            'Please review the code in "%s"',
+            $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $migrationName
+          ));
+          $this->logSection('propel', 'Migration aborted', null, 'ERROR');
+          return self::NOT_OK;
+        }
+        $this->logSection('propel', sprintf(
+          '%d of %d SQL statements executed successfully on datasource "%s"',
+          $res,
+          count($statements),
+          $datasource
+        ));
+      }
+
+      $manager->addExecutedMigration($migrationName);
+
+      if ($options['verbose']) {
+        $this->logSection('propel', sprintf('  Added %s to executed migrations', $migrationName), null, 'COMMENT');
+      }
+
+      $migration->postUp($manager);
+    }
+
+    $this->logSection('propel', 'Migration complete. No further migration to execute.');
+
+    return self::OK;
+  }
 
 }

--- a/lib/task/sfPropelMigrateTask.class.php
+++ b/lib/task/sfPropelMigrateTask.class.php
@@ -81,6 +81,7 @@ EOF;
             ));
 
             $migration = $manager->getMigrationObject($migrationName);
+
             if (false === $migration->preUp($manager))
             {
                 $this->logSection('propel', 'preUp() returned false. Aborting migration.', null, 'ERROR');
@@ -113,7 +114,6 @@ EOF;
                     {
                         $this->logSection(sprintf('Failed to execute SQL "%s". Aborting migration.', $statement), null, 'ERROR');
                         return self::NOT_OK;
-                        // continue
                     }
                 }
                 if (!$res)
@@ -131,7 +131,9 @@ EOF;
                     count($statements),
                     $datasource
                 ));
+
                 $manager->addExecutedMigration($datasource, $migrationName);
+
                 if ($options['verbose'])
                 {
                     $this->logSection('propel', sprintf('  Added %s to executed migrations for datasource "%s"', $migrationName, $datasource), null, 'COMMENT');

--- a/lib/task/sfPropelMigrateTask.class.php
+++ b/lib/task/sfPropelMigrateTask.class.php
@@ -73,8 +73,6 @@ EOF;
             $this->logSection('propel', sprintf('%d migrations to execute', count($missingMigrations)));
         }
 
-        $batch = $manager->getLatestBatch() + 1;
-
         foreach ($missingMigrations as $migrationName)
         {
             $this->logSection('propel', sprintf(
@@ -133,7 +131,7 @@ EOF;
                     count($statements),
                     $datasource
                 ));
-                $manager->addExecutedMigration($datasource, $migrationName, $batch);
+                $manager->addExecutedMigration($datasource, $migrationName);
                 if ($options['verbose'])
                 {
                     $this->logSection('propel', sprintf('  Added %s to executed migrations for datasource "%s"', $migrationName, $datasource), null, 'COMMENT');

--- a/lib/task/sfPropelMigrateTask.class.php
+++ b/lib/task/sfPropelMigrateTask.class.php
@@ -132,12 +132,14 @@ EOF;
                     $datasource
                 ));
 
-                $manager->addExecutedMigration($datasource, $migrationName);
-
                 if ($options['verbose'])
                 {
                     $this->logSection('propel', sprintf('  Added %s to executed migrations for datasource "%s"', $migrationName, $datasource), null, 'COMMENT');
                 }
+            }
+
+            foreach ($migration->getUpSQL() as $datasource => $sql) {
+                $manager->addExecutedMigration($datasource, $migrationName);
             }
 
             $migration->postUp($manager);

--- a/lib/task/sfPropelMigrateTask.class.php
+++ b/lib/task/sfPropelMigrateTask.class.php
@@ -56,9 +56,8 @@ EOF;
         $connections = $this->getConnections($databaseManager);
         $manager = new sfPropelMigrationManager();
         $manager->setConnections($connections);
+        $manager->setMigrationDir(sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir']);
         $manager->setMigrationTable($options['migration-table']);
-        $migrationDirectory = sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir'];
-        $manager->setMigrationDir($migrationDirectory);
 
         $missingMigrations = $manager->getMissingMigrationNames();
 
@@ -131,15 +130,13 @@ EOF;
                     count($statements),
                     $datasource
                 ));
-
-                if ($options['verbose'])
-                {
-                    $this->logSection('propel', sprintf('  Added %s to executed migrations for datasource "%s"', $migrationName, $datasource), null, 'COMMENT');
-                }
             }
 
-            foreach ($migration->getUpSQL() as $datasource => $sql) {
-                $manager->addExecutedMigration($datasource, $migrationName);
+            $manager->addExecutedMigration($migrationName);
+
+            if ($options['verbose'])
+            {
+                $this->logSection('propel', sprintf('  Added %s to executed migrations', $migrationName), null, 'COMMENT');
             }
 
             $migration->postUp($manager);

--- a/lib/task/sfPropelMigrateTask.class.php
+++ b/lib/task/sfPropelMigrateTask.class.php
@@ -22,128 +22,130 @@ class sfPropelMigrateTask extends sfPropelBaseTask
     private const NOT_OK = 1;
 
     /**
-   * @see sfTask
-   */
-  protected function configure()
-  {
-    $this->addOptions(array(
-      new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
-      new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
-      new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
-      new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'propel_migration'),
-      new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
-    ));
-    $this->namespace = 'propel';
-    $this->name = 'migrate';
-    $this->aliases = array('migration-all');
-    $this->briefDescription = 'Executes the next migrations up';
+     * @see sfTask
+     */
+    protected function configure()
+    {
+        $this->addOptions(array(
+            new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
+            new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
+            new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
+            new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'migration'),
+            new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
+        ));
+        $this->namespace = 'propel';
+        $this->name = 'migrate';
+        $this->aliases = array('migration-all');
+        $this->briefDescription = 'Executes the next migrations up';
 
-    $this->detailedDescription = <<<EOF
+        $this->detailedDescription = <<<EOF
 The [propel:up|INFO] checks the version of the database structure, looks for migration files not yet executed (i.e. with a greater version timestamp), and executes them.
 
 The task reads the database connection settings in [config/databases.yml|COMMENT].
 
 The task looks for migration classes in [lib/model/migration|COMMENT].
 EOF;
-  }
-
-  /**
-   * @see sfTask
-   */
-  protected function execute($arguments = array(), $options = array())
-  {
-    $databaseManager = new sfDatabaseManager($this->configuration);
-    $connections = $this->getConnections($databaseManager);
-    $manager = new PropelMigrationManager();
-    $manager->setConnections($connections);
-    $manager->setMigrationTable($options['migration-table']);
-    $migrationDirectory = sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir'];
-    $manager->setMigrationDir($migrationDirectory);
-
-    if (!$nextMigrationTimestamp = $manager->getFirstUpMigrationTimestamp())
-    {
-      $this->logSection('propel', 'All migrations were already executed - nothing to migrate.');
-      return self::OK;
     }
 
-    $timestamps = $manager->getValidMigrationTimestamps();
-    if (count($timestamps) > 1)
+    /**
+     * @see sfTask
+     */
+    protected function execute($arguments = array(), $options = array())
     {
-      $this->logSection('propel', sprintf('%d migrations to execute', count($timestamps)));
-    }
+        $databaseManager = new sfDatabaseManager($this->configuration);
+        $connections = $this->getConnections($databaseManager);
+        $manager = new sfPropelMigrationManager();
+        $manager->setConnections($connections);
+        $manager->setMigrationTable($options['migration-table']);
+        $migrationDirectory = sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir'];
+        $manager->setMigrationDir($migrationDirectory);
 
-    foreach ($timestamps as $timestamp)
-    {
-      $this->logSection('propel', sprintf(
-        'Executing migration %s up',
-        $manager->getMigrationClassName($timestamp)
-      ));
+        $missingMigrations = $manager->getMissingMigrationNames();
 
-      $migration = $manager->getMigrationObject($timestamp);
-      if (false === $migration->preUp($manager))
-      {
-        $this->logSection('propel', 'preUp() returned false. Aborting migration.', null, 'ERROR');
-        return self::NOT_OK;
-      }
-
-      foreach ($migration->getUpSQL() as $datasource => $sql)
-      {
-        $connection = $manager->getConnection($datasource);
-        if ($options['verbose'])
+        if (empty($missingMigrations))
         {
-          $this->logSection('propel', sprintf('  Connecting to database "%s" using DSN "%s"', $datasource, $connection['dsn']), null, 'COMMENT');
+            $this->logSection('propel', 'All migrations were already executed - nothing to migrate.');
+            return self::OK;
         }
-        $pdo = $manager->getPdoConnection($datasource);
-        $res = self::OK;
-        $statements = PropelSQLParser::parseString($sql);
-        foreach ($statements as $statement)
+
+        if (count($missingMigrations) > 1)
         {
-          try
-          {
-            if ($options['verbose'])
+            $this->logSection('propel', sprintf('%d migrations to execute', count($missingMigrations)));
+        }
+
+        $batch = $manager->getLatestBatch() + 1;
+
+        foreach ($missingMigrations as $migrationName)
+        {
+            $this->logSection('propel', sprintf(
+                'Executing migration %s up',
+                $migrationName
+            ));
+
+            $migration = $manager->getMigrationObject($migrationName);
+            if (false === $migration->preUp($manager))
             {
-              $this->logSection('propel', sprintf('  Executing statement "%s"', $statement), null, 'COMMENT');
+                $this->logSection('propel', 'preUp() returned false. Aborting migration.', null, 'ERROR');
+                return self::NOT_OK;
             }
-            $stmt = $pdo->prepare($statement);
-            $stmt->execute();
-            $res++;
-          }
-          catch (PDOException $e)
-          {
-            $this->logSection(sprintf('Failed to execute SQL "%s". Aborting migration.', $statement), null, 'ERROR');
-            return self::NOT_OK;
-            // continue
-          }
-        }
-        if (!$res)
-        {
-          $this->logSection('propel', 'No statement was executed. The version was not updated.');
-          $this->logSection('propel', sprintf(
-            'Please review the code in "%s"',
-            $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $manager->getMigrationClassName($timestamp)
-          ));
-          $this->logSection('propel', 'Migration aborted', null, 'ERROR');
-          return self::NOT_OK;
-        }
-        $this->logSection('propel', sprintf(
-          '%d of %d SQL statements executed successfully on datasource "%s"',
-          $res,
-          count($statements),
-          $datasource
-        ));
-        $manager->updateLatestMigrationTimestamp($datasource, $timestamp);
-        if ($options['verbose'])
-        {
-          $this->logSection('propel', sprintf('  Updated latest migration date to %d for datasource "%s"', $timestamp, $datasource), null, 'COMMENT');
-        }
-      }
 
-      $migration->postUp($manager);
+            foreach ($migration->getUpSQL() as $datasource => $sql)
+            {
+                $connection = $manager->getConnection($datasource);
+                if ($options['verbose'])
+                {
+                    $this->logSection('propel', sprintf('  Connecting to database "%s" using DSN "%s"', $datasource, $connection['dsn']), null, 'COMMENT');
+                }
+                $pdo = $manager->getPdoConnection($datasource);
+                $res = self::OK;
+                $statements = PropelSQLParser::parseString($sql);
+                foreach ($statements as $statement)
+                {
+                    try
+                    {
+                        if ($options['verbose'])
+                        {
+                            $this->logSection('propel', sprintf('  Executing statement "%s"', $statement), null, 'COMMENT');
+                        }
+                        $stmt = $pdo->prepare($statement);
+                        $stmt->execute();
+                        $res++;
+                    }
+                    catch (PDOException $e)
+                    {
+                        $this->logSection(sprintf('Failed to execute SQL "%s". Aborting migration.', $statement), null, 'ERROR');
+                        return self::NOT_OK;
+                        // continue
+                    }
+                }
+                if (!$res)
+                {
+                    $this->logSection('propel', sprintf(
+                        'Please review the code in "%s"',
+                        $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $migrationName
+                    ));
+                    $this->logSection('propel', 'Migration aborted', null, 'ERROR');
+                    return self::NOT_OK;
+                }
+                $this->logSection('propel', sprintf(
+                    '%d of %d SQL statements executed successfully on datasource "%s"',
+                    $res,
+                    count($statements),
+                    $datasource
+                ));
+                $manager->addExecutedMigration($datasource, $migrationName, $batch);
+                if ($options['verbose'])
+                {
+                    $this->logSection('propel', sprintf('  Added %s to executed migrations for datasource "%s"', $migrationName, $datasource), null, 'COMMENT');
+                }
+            }
+
+            $migration->postUp($manager);
+        }
+
+        $this->logSection('propel', 'Migration complete. No further migration to execute.');
+
+        return self::OK;
     }
-
-    $this->logSection('propel', 'Migration complete. No further migration to execute.');
-
-    return self::OK;
-  }
 
 }

--- a/lib/task/sfPropelMigrateTask.class.php
+++ b/lib/task/sfPropelMigrateTask.class.php
@@ -30,7 +30,7 @@ class sfPropelMigrateTask extends sfPropelBaseTask
             new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
             new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
             new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
-            new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'migration'),
+            new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'propel_migration'),
             new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
         ));
         $this->namespace = 'propel';

--- a/lib/task/sfPropelMigrateUpTask.class.php
+++ b/lib/task/sfPropelMigrateUpTask.class.php
@@ -18,132 +18,137 @@
  */
 class sfPropelMigrateUpTask extends sfPropelBaseTask
 {
-  private const OK = 0;
-  private const NOT_OK = 1;
+    private const OK = 0;
+    private const NOT_OK = 1;
 
-  /**
-   * @see sfTask
-   */
-  protected function configure()
-  {
-    $this->addOptions(array(
-      new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
-      new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
-      new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
-      new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'propel_migration'),
-      new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
-    ));
-    $this->namespace = 'propel';
-    $this->name = 'up';
-    $this->aliases = array('migration-up');
-    $this->briefDescription = 'Executes the next migration up';
+    /**
+     * @see sfTask
+     */
+    protected function configure()
+    {
+        $this->addOptions(array(
+            new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
+            new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
+            new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
+            new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'migration'),
+            new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
+        ));
+        $this->namespace = 'propel';
+        $this->name = 'up';
+        $this->aliases = array('migration-up');
+        $this->briefDescription = 'Executes the next migration up';
 
-    $this->detailedDescription = <<<EOF
+        $this->detailedDescription = <<<EOF
 The [propel:up|INFO] checks the version of the database structure, and looks for migration files not yet executed (i.e. with a greater version timestamp). The first migration found is executed.
 
 The task reads the database connection settings in [config/databases.yml|COMMENT].
 
 The task looks for migration classes in [lib/model/migration|COMMENT].
 EOF;
-  }
-
-  /**
-   * @see sfTask
-   */
-  protected function execute($arguments = array(), $options = array())
-  {
-    $databaseManager = new sfDatabaseManager($this->configuration);
-    $connections = $this->getConnections($databaseManager);
-    $manager = new PropelMigrationManager();
-    $manager->setConnections($connections);
-    $manager->setMigrationTable($options['migration-table']);
-    $migrationDirectory = sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir'];
-    $manager->setMigrationDir($migrationDirectory);
-
-    if (!$nextMigrationTimestamp = $manager->getFirstUpMigrationTimestamp())
-    {
-      $this->logSection('propel', 'All migrations were already executed - nothing to migrate.');
-      return self::OK;
-    }
-    $this->logSection('propel', sprintf(
-      'Executing migration %s up',
-      $manager->getMigrationClassName($nextMigrationTimestamp)
-    ));
-
-    $migration = $manager->getMigrationObject($nextMigrationTimestamp);
-    if (false === $migration->preUp($manager))
-    {
-      $this->logSection('propel', 'preUp() returned false. Aborting migration.', null, 'ERROR');
-      return self::NOT_OK;
     }
 
-    foreach ($migration->getUpSQL() as $datasource => $sql)
+    /**
+     * @see sfTask
+     */
+    protected function execute($arguments = array(), $options = array())
     {
-      $connection = $manager->getConnection($datasource);
-      if ($options['verbose'])
-      {
-        $this->logSection('propel', sprintf('  Connecting to database "%s" using DSN "%s"', $datasource, $connection['dsn']), null, 'COMMENT');
-      }
-      $pdo = $manager->getPdoConnection($datasource);
-      $res = 0;
-      $statements = PropelSQLParser::parseString($sql);
-      foreach ($statements as $statement)
-      {
-        try
+        $databaseManager = new sfDatabaseManager($this->configuration);
+        $connections = $this->getConnections($databaseManager);
+        $manager = new sfPropelMigrationManager();
+        $manager->setConnections($connections);
+        $manager->setMigrationTable($options['migration-table']);
+        $migrationDirectory = sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir'];
+        $manager->setMigrationDir($migrationDirectory);
+
+        $missingMigrations = $manager->getMissingMigrationNames();
+
+        if (empty($missingMigrations))
         {
-          if ($options['verbose'])
-          {
-            $this->logSection('propel', sprintf('  Executing statement "%s"', $statement), null, 'COMMENT');
-          }
-          $stmt = $pdo->prepare($statement);
-          $stmt->execute();
-          $res++;
+            $this->logSection('propel', 'All migrations were already executed - nothing to migrate.');
+            return self::OK;
         }
-        catch (PDOException $e)
-        {
-          $this->logSection(sprintf('Failed to execute SQL "%s". Aborting migration.', $statement), null, 'ERROR');
-          return self::NOT_OK;
-          // continue
-        }
-      }
-      if (!$res)
-      {
-        $this->logSection('propel', 'No statement was executed. The version was not updated.');
+
+        $migrationName = array_shift($missingMigrations);
+
         $this->logSection('propel', sprintf(
-          'Please review the code in "%s"',
-          $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $manager->getMigrationClassName($nextMigrationTimestamp)
+            'Executing migration %s up',
+            $migrationName
         ));
-        $this->logSection('propel', 'Migration aborted', null, 'ERROR');
-        return self::NOT_OK;
-      }
-      $this->logSection('propel', sprintf(
-        '%d of %d SQL statements executed successfully on datasource "%s"',
-        $res,
-        count($statements),
-        $datasource
-      ));
-      $manager->updateLatestMigrationTimestamp($datasource, $nextMigrationTimestamp);
-      if ($options['verbose'])
-      {
-        $this->logSection('propel', sprintf('  Updated latest migration date to %d for datasource "%s"', $nextMigrationTimestamp, $datasource), null, 'COMMENT');
-      }
-    }
 
-    $migration->postUp($manager);
+        $migration = $manager->getMigrationObject($migrationName);
+        if (false === $migration->preUp($manager))
+        {
+            $this->logSection('propel', 'preUp() returned false. Aborting migration.', null, 'ERROR');
+            return self::NOT_OK;
+        }
 
-    if ($timestamps = $manager->getValidMigrationTimestamps())
-    {
-      $this->logSection('propel', sprintf(
-        'Migration complete. %d migrations left to execute.',
-        count($timestamps)
-      ));
-    }
-    else
-    {
-      $this->logSection('propel', 'Migration complete. No further migration to execute.');
-    }
+        foreach ($migration->getUpSQL() as $datasource => $sql)
+        {
+            $connection = $manager->getConnection($datasource);
+            if ($options['verbose'])
+            {
+                $this->logSection('propel', sprintf('  Connecting to database "%s" using DSN "%s"', $datasource, $connection['dsn']), null, 'COMMENT');
+            }
+            $pdo = $manager->getPdoConnection($datasource);
+            $res = 0;
+            $statements = PropelSQLParser::parseString($sql);
+            foreach ($statements as $statement)
+            {
+                try
+                {
+                    if ($options['verbose'])
+                    {
+                        $this->logSection('propel', sprintf('  Executing statement "%s"', $statement), null, 'COMMENT');
+                    }
+                    $stmt = $pdo->prepare($statement);
+                    $stmt->execute();
+                    $res++;
+                }
+                catch (PDOException $e)
+                {
+                    $this->logSection(sprintf('Failed to execute SQL "%s". Aborting migration.', $statement), null, 'ERROR');
+                    return self::NOT_OK;
+                    // continue
+                }
+            }
+            if (!$res)
+            {
+                $this->logSection('propel', 'No statement was executed. The version was not updated.');
+                $this->logSection('propel', sprintf(
+                    'Please review the code in "%s"',
+                    $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $migrationName
+                ));
+                $this->logSection('propel', 'Migration aborted', null, 'ERROR');
+                return self::NOT_OK;
+            }
+            $this->logSection('propel', sprintf(
+                '%d of %d SQL statements executed successfully on datasource "%s"',
+                $res,
+                count($statements),
+                $datasource
+            ));
+            $manager->addExecutedMigration($datasource, $migrationName);
+            if ($options['verbose'])
+            {
+                $this->logSection('propel', sprintf('  Added %s to executed migrations for datasource "%s"', $migrationName, $datasource), null, 'COMMENT');
+            }
+        }
 
-    return self::OK;
-  }
+        $migration->postUp($manager);
+
+        if (count($missingMigrations))
+        {
+            $this->logSection('propel', sprintf(
+                'Migration complete. %d migrations left to execute.',
+                count($missingMigrations)
+            ));
+        }
+        else
+        {
+            $this->logSection('propel', 'Migration complete. No further migration to execute.');
+        }
+
+        return self::OK;
+    }
 
 }

--- a/lib/task/sfPropelMigrateUpTask.class.php
+++ b/lib/task/sfPropelMigrateUpTask.class.php
@@ -30,7 +30,7 @@ class sfPropelMigrateUpTask extends sfPropelBaseTask
             new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
             new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
             new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
-            new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'migration'),
+            new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'propel_migration'),
             new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
         ));
         $this->namespace = 'propel';

--- a/lib/task/sfPropelMigrateUpTask.class.php
+++ b/lib/task/sfPropelMigrateUpTask.class.php
@@ -18,140 +18,126 @@
  */
 class sfPropelMigrateUpTask extends sfPropelBaseTask
 {
-    private const OK = 0;
-    private const NOT_OK = 1;
+  private const OK = 0;
+  private const NOT_OK = 1;
 
-    /**
-     * @see sfTask
-     */
-    protected function configure()
-    {
-        $this->addOptions(array(
-            new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
-            new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
-            new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
-            new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'propel_migration'),
-            new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
-        ));
-        $this->namespace = 'propel';
-        $this->name = 'up';
-        $this->aliases = array('migration-up');
-        $this->briefDescription = 'Executes the next migration up';
+  /**
+   * @see sfTask
+   */
+  protected function configure()
+  {
+    $this->addOptions(array(
+      new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
+      new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
+      new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
+      new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'propel_migration'),
+      new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
+    ));
+    $this->namespace = 'propel';
+    $this->name = 'up';
+    $this->aliases = array('migration-up');
+    $this->briefDescription = 'Executes the next migration up';
 
-        $this->detailedDescription = <<<EOF
+    $this->detailedDescription = <<<EOF
 The [propel:up|INFO] checks the version of the database structure, and looks for migration files not yet executed (i.e. with a greater version timestamp). The first migration found is executed.
 
 The task reads the database connection settings in [config/databases.yml|COMMENT].
 
 The task looks for migration classes in [lib/model/migration|COMMENT].
 EOF;
+  }
+
+  /**
+   * @see sfTask
+   */
+  protected function execute($arguments = array(), $options = array())
+  {
+    $databaseManager = new sfDatabaseManager($this->configuration);
+    $connections = $this->getConnections($databaseManager);
+    $manager = new sfPropelMigrationManager();
+    $manager->setConnections($connections);
+    $manager->setMigrationDir(sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir']);
+    $manager->setMigrationTable($options['migration-table']);
+
+    $missingMigrations = $manager->getMissingMigrationNames();
+
+    if (empty($missingMigrations)) {
+      $this->logSection('propel', 'All migrations were already executed - nothing to migrate.');
+      return self::OK;
     }
 
-    /**
-     * @see sfTask
-     */
-    protected function execute($arguments = array(), $options = array())
-    {
-        $databaseManager = new sfDatabaseManager($this->configuration);
-        $connections = $this->getConnections($databaseManager);
-        $manager = new sfPropelMigrationManager();
-        $manager->setConnections($connections);
-        $manager->setMigrationDir(sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir']);
-        $manager->setMigrationTable($options['migration-table']);
+    $migrationName = array_shift($missingMigrations);
 
-        $missingMigrations = $manager->getMissingMigrationNames();
+    $this->logSection('propel', sprintf(
+      'Executing migration %s up',
+      $migrationName
+    ));
 
-        if (empty($missingMigrations))
-        {
-            $this->logSection('propel', 'All migrations were already executed - nothing to migrate.');
-            return self::OK;
+    $migration = $manager->getMigrationObject($migrationName);
+
+    if (false === $migration->preUp($manager)) {
+      $this->logSection('propel', 'preUp() returned false. Aborting migration.', null, 'ERROR');
+      return self::NOT_OK;
+    }
+
+    foreach ($migration->getUpSQL() as $datasource => $sql) {
+      $connection = $manager->getConnection($datasource);
+      if ($options['verbose']) {
+        $this->logSection('propel', sprintf('  Connecting to database "%s" using DSN "%s"', $datasource, $connection['dsn']), null, 'COMMENT');
+      }
+      $pdo = $manager->getPdoConnection($datasource);
+      $res = 0;
+      $statements = PropelSQLParser::parseString($sql);
+      foreach ($statements as $statement) {
+        try {
+          if ($options['verbose']) {
+            $this->logSection('propel', sprintf('  Executing statement "%s"', $statement), null, 'COMMENT');
+          }
+          $stmt = $pdo->prepare($statement);
+          $stmt->execute();
+          $res++;
+        } catch (PDOException $e) {
+          $this->logSection(sprintf('Failed to execute SQL "%s". Aborting migration.', $statement), null, 'ERROR');
+          return self::NOT_OK;
         }
-
-        $migrationName = array_shift($missingMigrations);
-
+      }
+      if (!$res) {
+        $this->logSection('propel', 'No statement was executed. The version was not updated.');
         $this->logSection('propel', sprintf(
-            'Executing migration %s up',
-            $migrationName
+          'Please review the code in "%s"',
+          $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $migrationName
         ));
-
-        $migration = $manager->getMigrationObject($migrationName);
-
-        if (false === $migration->preUp($manager))
-        {
-            $this->logSection('propel', 'preUp() returned false. Aborting migration.', null, 'ERROR');
-            return self::NOT_OK;
-        }
-
-        foreach ($migration->getUpSQL() as $datasource => $sql)
-        {
-            $connection = $manager->getConnection($datasource);
-            if ($options['verbose'])
-            {
-                $this->logSection('propel', sprintf('  Connecting to database "%s" using DSN "%s"', $datasource, $connection['dsn']), null, 'COMMENT');
-            }
-            $pdo = $manager->getPdoConnection($datasource);
-            $res = 0;
-            $statements = PropelSQLParser::parseString($sql);
-            foreach ($statements as $statement)
-            {
-                try
-                {
-                    if ($options['verbose'])
-                    {
-                        $this->logSection('propel', sprintf('  Executing statement "%s"', $statement), null, 'COMMENT');
-                    }
-                    $stmt = $pdo->prepare($statement);
-                    $stmt->execute();
-                    $res++;
-                }
-                catch (PDOException $e)
-                {
-                    $this->logSection(sprintf('Failed to execute SQL "%s". Aborting migration.', $statement), null, 'ERROR');
-                    return self::NOT_OK;
-                }
-            }
-            if (!$res)
-            {
-                $this->logSection('propel', 'No statement was executed. The version was not updated.');
-                $this->logSection('propel', sprintf(
-                    'Please review the code in "%s"',
-                    $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $migrationName
-                ));
-                $this->logSection('propel', 'Migration aborted', null, 'ERROR');
-                return self::NOT_OK;
-            }
-            $this->logSection('propel', sprintf(
-                '%d of %d SQL statements executed successfully on datasource "%s"',
-                $res,
-                count($statements),
-                $datasource
-            ));
-        }
-
-        $manager->addExecutedMigration($migrationName);
-
-        if ($options['verbose'])
-        {
-            $this->logSection('propel', sprintf('  Added %s to executed migrations', $migrationName), null, 'COMMENT');
-        }
-
-        $migration->postUp($manager);
-
-        $countMissingMigrations = count($missingMigrations);
-
-        if ($countMissingMigrations)
-        {
-            $this->logSection('propel', sprintf(
-                'Migration complete. %d migrations left to execute.',
-                $countMissingMigrations
-            ));
-        }
-        else
-        {
-            $this->logSection('propel', 'Migration complete. No further migration to execute.');
-        }
-
-        return self::OK;
+        $this->logSection('propel', 'Migration aborted', null, 'ERROR');
+        return self::NOT_OK;
+      }
+      $this->logSection('propel', sprintf(
+        '%d of %d SQL statements executed successfully on datasource "%s"',
+        $res,
+        count($statements),
+        $datasource
+      ));
     }
+
+    $manager->addExecutedMigration($migrationName);
+
+    if ($options['verbose']) {
+      $this->logSection('propel', sprintf('  Added %s to executed migrations', $migrationName), null, 'COMMENT');
+    }
+
+    $migration->postUp($manager);
+
+    $countMissingMigrations = count($missingMigrations);
+
+    if ($countMissingMigrations) {
+      $this->logSection('propel', sprintf(
+        'Migration complete. %d migrations left to execute.',
+        $countMissingMigrations
+      ));
+    } else {
+      $this->logSection('propel', 'Migration complete. No further migration to execute.');
+    }
+
+    return self::OK;
+  }
 
 }

--- a/lib/task/sfPropelMigrateUpTask.class.php
+++ b/lib/task/sfPropelMigrateUpTask.class.php
@@ -56,9 +56,8 @@ EOF;
         $connections = $this->getConnections($databaseManager);
         $manager = new sfPropelMigrationManager();
         $manager->setConnections($connections);
+        $manager->setMigrationDir(sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir']);
         $manager->setMigrationTable($options['migration-table']);
-        $migrationDirectory = sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir'];
-        $manager->setMigrationDir($migrationDirectory);
 
         $missingMigrations = $manager->getMissingMigrationNames();
 
@@ -127,13 +126,13 @@ EOF;
                 count($statements),
                 $datasource
             ));
+        }
 
-            $manager->addExecutedMigration($datasource, $migrationName);
+        $manager->addExecutedMigration($migrationName);
 
-            if ($options['verbose'])
-            {
-                $this->logSection('propel', sprintf('  Added %s to executed migrations for datasource "%s"', $migrationName, $datasource), null, 'COMMENT');
-            }
+        if ($options['verbose'])
+        {
+            $this->logSection('propel', sprintf('  Added %s to executed migrations', $migrationName), null, 'COMMENT');
         }
 
         $migration->postUp($manager);

--- a/lib/task/sfPropelMigrateUpTask.class.php
+++ b/lib/task/sfPropelMigrateUpTask.class.php
@@ -76,6 +76,7 @@ EOF;
         ));
 
         $migration = $manager->getMigrationObject($migrationName);
+
         if (false === $migration->preUp($manager))
         {
             $this->logSection('propel', 'preUp() returned false. Aborting migration.', null, 'ERROR');
@@ -108,7 +109,6 @@ EOF;
                 {
                     $this->logSection(sprintf('Failed to execute SQL "%s". Aborting migration.', $statement), null, 'ERROR');
                     return self::NOT_OK;
-                    // continue
                 }
             }
             if (!$res)
@@ -127,7 +127,9 @@ EOF;
                 count($statements),
                 $datasource
             ));
+
             $manager->addExecutedMigration($datasource, $migrationName);
+
             if ($options['verbose'])
             {
                 $this->logSection('propel', sprintf('  Added %s to executed migrations for datasource "%s"', $migrationName, $datasource), null, 'COMMENT');
@@ -136,11 +138,13 @@ EOF;
 
         $migration->postUp($manager);
 
-        if (count($missingMigrations))
+        $countMissingMigrations = count($missingMigrations);
+
+        if ($countMissingMigrations)
         {
             $this->logSection('propel', sprintf(
                 'Migration complete. %d migrations left to execute.',
-                count($missingMigrations)
+                $countMissingMigrations
             ));
         }
         else

--- a/lib/task/sfPropelStatusTask.class.php
+++ b/lib/task/sfPropelStatusTask.class.php
@@ -18,124 +18,113 @@
  */
 class sfPropelStatusTask extends sfPropelBaseTask
 {
-  /**
-   * @see sfTask
-   */
-  protected function configure()
-  {
-    $this->addOptions(array(
-      new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
-      new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
-      new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
-      new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'propel_migration'),
-      new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
-    ));
-    $this->namespace = 'propel';
-    $this->name = 'status';
-    $this->aliases = array('migration-status');
-    $this->briefDescription = 'Lists the migrations yet to be executed';
+    /**
+     * @see sfTask
+     */
+    protected function configure()
+    {
+        $this->addOptions(array(
+            new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
+            new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
+            new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
+            new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'migration'),
+            new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
+        ));
+        $this->namespace = 'propel';
+        $this->name = 'status';
+        $this->aliases = array('migration-status');
+        $this->briefDescription = 'Lists the migrations yet to be executed';
 
-    $this->detailedDescription = <<<EOF
+        $this->detailedDescription = <<<EOF
 The [propel:status|INFO] checks the version of the database structure, and looks for migration files not yet executed (i.e. with a greater version timestamp).
 
 The task reads the database connection settings in [config/databases.yml|COMMENT].
 
 The task looks for migration classes in [lib/model/migration|COMMENT].
 EOF;
-  }
+    }
 
-  /**
-   * @see sfTask
-   */
-  protected function execute($arguments = array(), $options = array())
-  {
-    $databaseManager = new sfDatabaseManager($this->configuration);
-    $connections = $this->getConnections($databaseManager);
-    $manager = new PropelMigrationManager();
-    $manager->setConnections($connections);
-    $manager->setMigrationTable($options['migration-table']);
-    $migrationDirectory = sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir'];
-    $manager->setMigrationDir($migrationDirectory);
-
-    $this->logSection('propel', 'Checking Database Versions...');
-    foreach ($connections as $name => $params)
+    /**
+     * @see sfTask
+     */
+    protected function execute($arguments = array(), $options = array())
     {
-      if ($options['verbose'])
-      {
-        $this->logSection('propel', sprintf('  Connecting to database "%s" using DSN "%s"', $name, $params['dsn']), null, 'COMMENT');
-      }
-      if (!$manager->migrationTableExists($name))
-      {
-        if ($options['verbose'])
+        $databaseManager = new sfDatabaseManager($this->configuration);
+        $connections = $this->getConnections($databaseManager);
+        $manager = new sfPropelMigrationManager();
+        $manager->setConnections($connections);
+        $manager->setMigrationTable($options['migration-table']);
+        $migrationDirectory = sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir'];
+        $manager->setMigrationDir($migrationDirectory);
+
+        $this->logSection('propel', 'Checking Database Versions...');
+        foreach ($connections as $name => $params)
         {
-          $this->logSection('propel', sprintf('  Migration table does not exist in datasource "%s"; creating it.', $name), null, 'COMMENT');
+            if ($options['verbose'])
+            {
+                $this->logSection('propel', sprintf('  Connecting to database "%s" using DSN "%s"', $name, $params['dsn']), null, 'COMMENT');
+            }
+            if (!$manager->migrationTableExists($name))
+            {
+                if ($options['verbose'])
+                {
+                    $this->logSection('propel', sprintf('  Migration table does not exist in datasource "%s"; creating it.', $name), null, 'COMMENT');
+                }
+                $manager->createMigrationTable($name);
+            }
         }
-        $manager->createMigrationTable($name);
-      }
-    }
 
-    $oldestMigrationTimestamp = $manager->getOldestDatabaseVersion();
-    if ($options['verbose'])
-    {
-      if ($oldestMigrationTimestamp)
-      {
-        $this->logSection('propel', sprintf('  Latest migration was executed on %s (timestamp %d)', date('Y-m-d H:i:s', $oldestMigrationTimestamp), $oldestMigrationTimestamp), null, 'COMMENT');
-      }
-      else
-      {
-        $this->logSection('propel', '  No migration was ever executed on these connection settings.', null, 'COMMENT');
-      }
-    }
+        $this->logSection('propel', 'Listing Migration files...');
 
-    $this->logSection('propel', 'Listing Migration files...');
-    $migrationTimestamps = $manager->getMigrationTimestamps();
-    $nbExistingMigrations = count($migrationTimestamps);
-    if ($migrationTimestamps)
-    {
-      if ($options['verbose'])
-      {
-        $this->logSection('propel', sprintf('  %d valid migration classes found in "%s"', $nbExistingMigrations, $options['migration-dir']), null, 'COMMENT');
-      }
-      if ($validTimestamps = $manager->getValidMigrationTimestamps())
-      {
-        $countValidTimestamps = count($validTimestamps);
-        if ($countValidTimestamps == 1)
+        $migrationNames = $manager->getExistingMigrationNames();
+        $missingMigrations = $manager->getMissingMigrationNames();
+        $executedMigrations = $manager->getExecutedMigrationNames();
+
+        if ($migrationNames)
         {
-          $this->logSection('propel', '1 migration needs to be executed:');
+            if ($options['verbose'])
+            {
+                $this->logSection('propel', sprintf('  %d valid migration classes found in "%s"', count($migrationNames), $options['migration-dir']), null, 'COMMENT');
+            }
+            if ($missingMigrations)
+            {
+                $countMissingMigrations = count($missingMigrations);
+                if ($countMissingMigrations == 1)
+                {
+                    $this->logSection('propel', '1 migration needs to be executed:');
+                }
+                else
+                {
+                    $this->logSection('propel', sprintf('%d migrations need to be executed:', $countMissingMigrations));
+                }
+            }
+            foreach ($migrationNames as $migrationName)
+            {
+                if (in_array($migrationName, $executedMigrations) && $options['verbose'])
+                {
+                    $this->logSection('propel', sprintf('  %s (executed)', $migrationName), null, 'COMMENT');
+                }
+                elseif (! in_array($migrationName, $executedMigrations))
+                {
+                    $this->logSection('propel', sprintf('    %s', $migrationName));
+                }
+            }
         }
         else
         {
-          $this->logSection('propel', sprintf('%d migrations need to be executed:', $countValidTimestamps));
+            $this->logSection('propel', sprintf('No migration file found in "%s".', $options['migration-dir']));
+            $this->logSection('propel', 'Make sure you run the sql-diff task.');
+            return false;
         }
-      }
-      foreach ($migrationTimestamps as $timestamp)
-      {
-        if ($timestamp <= $oldestMigrationTimestamp && $options['verbose'])
-        {
-          $this->logSection('propel', sprintf('  %s %s (executed)', $timestamp == $oldestMigrationTimestamp ? '>' : ' ', $manager->getMigrationClassName($timestamp)), null, 'COMMENT');
-        }
-        elseif ($timestamp > $oldestMigrationTimestamp)
-        {
-          $this->logSection('propel', sprintf('    %s', $manager->getMigrationClassName($timestamp)));
-        }
-      }
-    }
-    else
-    {
-      $this->logSection('propel', sprintf('No migration file found in "%s".', $options['migration-dir']));
-      $this->logSection('propel', 'Make sure you run the sql-diff task.');
-      return false;
-    }
 
-    $migrationTimestamps = $manager->getValidMigrationTimestamps();
-    $nbNotYetExecutedMigrations = count($migrationTimestamps);
-    if (!$nbNotYetExecutedMigrations)
-    {
-      $this->logSection('propel', 'All migration files were already executed - Nothing to migrate.');
-      return false;
+        $nbNotYetExecutedMigrations = count($missingMigrations);
+        if (!$nbNotYetExecutedMigrations)
+        {
+            $this->logSection('propel', 'All migration files were already executed - Nothing to migrate.');
+            return false;
+        }
+        $this->logSection('propel', sprintf('Call the "propel:migrate" task to execute %s', $countMissingMigrations == 1 ? 'it' : 'them'
+        ));
     }
-    $this->logSection('propel', sprintf('Call the "propel:migrate" task to execute %s', $countValidTimestamps == 1 ? 'it' : 'them'
-    ));
-  }
 
 }

--- a/lib/task/sfPropelStatusTask.class.php
+++ b/lib/task/sfPropelStatusTask.class.php
@@ -77,8 +77,10 @@ EOF;
         $this->logSection('propel', 'Listing Migration files...');
 
         $migrationNames = $manager->getExistingMigrationNames();
-        $missingMigrations = $manager->getMissingMigrationNames();
         $executedMigrations = $manager->getExecutedMigrationNames();
+        $missingMigrations = $manager->getMissingMigrationNames();
+
+        $countMissingMigrations = count($missingMigrations);
 
         if ($migrationNames)
         {
@@ -86,10 +88,9 @@ EOF;
             {
                 $this->logSection('propel', sprintf('  %d valid migration classes found in "%s"', count($migrationNames), $options['migration-dir']), null, 'COMMENT');
             }
-            if ($missingMigrations)
+            if ($countMissingMigrations)
             {
-                $countMissingMigrations = count($missingMigrations);
-                if ($countMissingMigrations == 1)
+                if ($countMissingMigrations === 1)
                 {
                     $this->logSection('propel', '1 migration needs to be executed:');
                 }
@@ -100,13 +101,13 @@ EOF;
             }
             foreach ($migrationNames as $migrationName)
             {
-                if (in_array($migrationName, $executedMigrations) && $options['verbose'])
-                {
-                    $this->logSection('propel', sprintf('  %s (executed)', $migrationName), null, 'COMMENT');
-                }
-                elseif (! in_array($migrationName, $executedMigrations))
+                if (!in_array($migrationName, $executedMigrations))
                 {
                     $this->logSection('propel', sprintf('    %s', $migrationName));
+                }
+                elseif ($options['verbose'])
+                {
+                    $this->logSection('propel', sprintf('  %s (executed)', $migrationName), null, 'COMMENT');
                 }
             }
         }
@@ -117,13 +118,15 @@ EOF;
             return false;
         }
 
-        $nbNotYetExecutedMigrations = count($missingMigrations);
-        if (!$nbNotYetExecutedMigrations)
+        if (!$countMissingMigrations)
         {
             $this->logSection('propel', 'All migration files were already executed - Nothing to migrate.');
             return false;
         }
-        $this->logSection('propel', sprintf('Call the "propel:migrate" task to execute %s', $countMissingMigrations == 1 ? 'it' : 'them'
+
+        $this->logSection('propel', sprintf(
+            'Call the "propel:migrate" task to execute %s',
+            $countMissingMigrations === 1 ? 'it' : 'them'
         ));
     }
 

--- a/lib/task/sfPropelStatusTask.class.php
+++ b/lib/task/sfPropelStatusTask.class.php
@@ -18,116 +18,100 @@
  */
 class sfPropelStatusTask extends sfPropelBaseTask
 {
-    /**
-     * @see sfTask
-     */
-    protected function configure()
-    {
-        $this->addOptions(array(
-            new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
-            new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
-            new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
-            new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'propel_migration'),
-            new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
-        ));
-        $this->namespace = 'propel';
-        $this->name = 'status';
-        $this->aliases = array('migration-status');
-        $this->briefDescription = 'Lists the migrations yet to be executed';
+  /**
+   * @see sfTask
+   */
+  protected function configure()
+  {
+    $this->addOptions(array(
+      new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
+      new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
+      new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
+      new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'propel_migration'),
+      new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
+    ));
+    $this->namespace = 'propel';
+    $this->name = 'status';
+    $this->aliases = array('migration-status');
+    $this->briefDescription = 'Lists the migrations yet to be executed';
 
-        $this->detailedDescription = <<<EOF
+    $this->detailedDescription = <<<EOF
 The [propel:status|INFO] checks the version of the database structure, and looks for migration files not yet executed (i.e. with a greater version timestamp).
 
 The task reads the database connection settings in [config/databases.yml|COMMENT].
 
 The task looks for migration classes in [lib/model/migration|COMMENT].
 EOF;
+  }
+
+  /**
+   * @see sfTask
+   */
+  protected function execute($arguments = array(), $options = array())
+  {
+    $databaseManager = new sfDatabaseManager($this->configuration);
+    $connections = $this->getConnections($databaseManager);
+    $manager = new sfPropelMigrationManager();
+    $manager->setConnections($connections);
+    $manager->setMigrationDir(sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir']);
+    $manager->setMigrationTable($options['migration-table']);
+
+    $this->logSection('propel', 'Checking Database Versions...');
+
+    $params = $this->getConnection($databaseManager, $manager->getMigrationDatabase());
+
+    if ($options['verbose']) {
+      $this->logSection('propel', sprintf('  Connecting to database "%s" using DSN "%s"', $manager->getMigrationDatabase(), $params['dsn']), null, 'COMMENT');
     }
 
-    /**
-     * @see sfTask
-     */
-    protected function execute($arguments = array(), $options = array())
-    {
-        $databaseManager = new sfDatabaseManager($this->configuration);
-        $connections = $this->getConnections($databaseManager);
-        $manager = new sfPropelMigrationManager();
-        $manager->setConnections($connections);
-        $manager->setMigrationDir(sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . $options['migration-dir']);
-        $manager->setMigrationTable($options['migration-table']);
-
-        $this->logSection('propel', 'Checking Database Versions...');
-
-        $params = $this->getConnection($databaseManager, $manager->getMigrationDatabase());
-
-        if ($options['verbose'])
-        {
-            $this->logSection('propel', sprintf('  Connecting to database "%s" using DSN "%s"', $manager->getMigrationDatabase(), $params['dsn']), null, 'COMMENT');
-        }
-
-        if (!$manager->migrationTableExists())
-        {
-            if ($options['verbose'])
-            {
-                $this->logSection('propel', sprintf('  Migration table does not exist in datasource "%s"; creating it.', $manager->getMigrationDatabase()), null, 'COMMENT');
-            }
-            $manager->createMigrationTable();
-        }
-
-        $this->logSection('propel', 'Listing Migration files...');
-
-        $migrationNames = $manager->getExistingMigrationNames();
-        $executedMigrations = $manager->getExecutedMigrationNames();
-        $missingMigrations = $manager->getMissingMigrationNames();
-
-        $countMissingMigrations = count($missingMigrations);
-
-        if ($migrationNames)
-        {
-            if ($options['verbose'])
-            {
-                $this->logSection('propel', sprintf('  %d valid migration classes found in "%s"', count($migrationNames), $options['migration-dir']), null, 'COMMENT');
-            }
-            if ($countMissingMigrations)
-            {
-                if ($countMissingMigrations === 1)
-                {
-                    $this->logSection('propel', '1 migration needs to be executed:');
-                }
-                else
-                {
-                    $this->logSection('propel', sprintf('%d migrations need to be executed:', $countMissingMigrations));
-                }
-            }
-            foreach ($migrationNames as $migrationName)
-            {
-                if (!in_array($migrationName, $executedMigrations))
-                {
-                    $this->logSection('propel', sprintf('    %s', $migrationName));
-                }
-                elseif ($options['verbose'])
-                {
-                    $this->logSection('propel', sprintf('  %s (executed)', $migrationName), null, 'COMMENT');
-                }
-            }
-        }
-        else
-        {
-            $this->logSection('propel', sprintf('No migration file found in "%s".', $options['migration-dir']));
-            $this->logSection('propel', 'Make sure you run the sql-diff task.');
-            return false;
-        }
-
-        if (!$countMissingMigrations)
-        {
-            $this->logSection('propel', 'All migration files were already executed - Nothing to migrate.');
-            return false;
-        }
-
-        $this->logSection('propel', sprintf(
-            'Call the "propel:migrate" task to execute %s',
-            $countMissingMigrations === 1 ? 'it' : 'them'
-        ));
+    if (!$manager->migrationTableExists()) {
+      if ($options['verbose']) {
+        $this->logSection('propel', sprintf('  Migration table does not exist in datasource "%s"; creating it.', $manager->getMigrationDatabase()), null, 'COMMENT');
+      }
+      $manager->createMigrationTable();
     }
+
+    $this->logSection('propel', 'Listing Migration files...');
+
+    $migrationNames = $manager->getExistingMigrationNames();
+    $executedMigrations = $manager->getExecutedMigrationNames();
+    $missingMigrations = $manager->getMissingMigrationNames();
+
+    $countMissingMigrations = count($missingMigrations);
+
+    if ($migrationNames) {
+      if ($options['verbose']) {
+        $this->logSection('propel', sprintf('  %d valid migration classes found in "%s"', count($migrationNames), $options['migration-dir']), null, 'COMMENT');
+      }
+      if ($countMissingMigrations) {
+        if ($countMissingMigrations === 1) {
+          $this->logSection('propel', '1 migration needs to be executed:');
+        } else {
+          $this->logSection('propel', sprintf('%d migrations need to be executed:', $countMissingMigrations));
+        }
+      }
+      foreach ($migrationNames as $migrationName) {
+        if (!in_array($migrationName, $executedMigrations)) {
+          $this->logSection('propel', sprintf('    %s', $migrationName));
+        } elseif ($options['verbose']) {
+          $this->logSection('propel', sprintf('  %s (executed)', $migrationName), null, 'COMMENT');
+        }
+      }
+    } else {
+      $this->logSection('propel', sprintf('No migration file found in "%s".', $options['migration-dir']));
+      $this->logSection('propel', 'Make sure you run the sql-diff task.');
+      return false;
+    }
+
+    if (!$countMissingMigrations) {
+      $this->logSection('propel', 'All migration files were already executed - Nothing to migrate.');
+      return false;
+    }
+
+    $this->logSection('propel', sprintf(
+      'Call the "propel:migrate" task to execute %s',
+      $countMissingMigrations === 1 ? 'it' : 'them'
+    ));
+  }
 
 }

--- a/lib/task/sfPropelStatusTask.class.php
+++ b/lib/task/sfPropelStatusTask.class.php
@@ -27,7 +27,7 @@ class sfPropelStatusTask extends sfPropelBaseTask
             new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
             new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'cli'),
             new sfCommandOption('migration-dir', null, sfCommandOption::PARAMETER_OPTIONAL, 'The migrations subdirectory', 'lib/model/migration'),
-            new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'migration'),
+            new sfCommandOption('migration-table', null, sfCommandOption::PARAMETER_OPTIONAL, 'The name of the migration table', 'propel_migration'),
             new sfCommandOption('verbose', null, sfCommandOption::PARAMETER_NONE, 'Enables verbose output'),
         ));
         $this->namespace = 'propel';

--- a/lib/util/sfPropelMigrationManager.php
+++ b/lib/util/sfPropelMigrationManager.php
@@ -19,7 +19,7 @@ class sfPropelMigrationManager
 {
     protected $connections;
     protected $pdoConnections = array();
-    protected $migrationTable = 'migration';
+    protected $migrationTable = 'propel_migration';
     protected $migrationDir;
 
     /**

--- a/lib/util/sfPropelMigrationManager.php
+++ b/lib/util/sfPropelMigrationManager.php
@@ -21,7 +21,7 @@ class sfPropelMigrationManager
   protected $pdoConnections = array();
   protected $migrationTable = 'propel_migration';
   protected $migrationDir;
-  protected $migrationDatabase = 'default';
+  protected $migrationDatabase;
 
   public function __construct()
   {

--- a/lib/util/sfPropelMigrationManager.php
+++ b/lib/util/sfPropelMigrationManager.php
@@ -1,0 +1,402 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+/**
+ * Service class for preparing and executing migrations
+ *
+ * @author     François Zaninotto
+ * @version    $Revision$
+ * @package    propel.generator.util
+ */
+class sfPropelMigrationManager
+{
+    protected $connections;
+    protected $pdoConnections = array();
+    protected $migrationTable = 'migration';
+    protected $migrationDir;
+
+    /**
+     * Set the database connection settings
+     *
+     * @param array $connections
+     */
+    public function setConnections($connections)
+    {
+        $this->connections = $connections;
+    }
+
+    /**
+     * Get the database connection settings
+     *
+     * @return array
+     */
+    public function getConnections()
+    {
+        return $this->connections;
+    }
+
+    public function getConnection($datasource)
+    {
+        if (!isset($this->connections[$datasource])) {
+            throw new InvalidArgumentException(sprintf('Unknown datasource "%s"', $datasource));
+        }
+
+        return $this->connections[$datasource];
+    }
+
+    public function getPdoConnection($datasource)
+    {
+        if (!isset($this->pdoConnections[$datasource])) {
+            $buildConnection = $this->getConnection($datasource);
+            $buildConnection['dsn'] = str_replace("@DB@", $datasource, $buildConnection['dsn']);
+
+            $this->pdoConnections[$datasource] = Propel::initConnection($buildConnection, $datasource);
+        }
+
+        return $this->pdoConnections[$datasource];
+    }
+
+    public function getPlatform($datasource)
+    {
+        $params = $this->getConnection($datasource);
+        $adapter = $params['adapter'];
+        $adapterClass = ucfirst($adapter) . 'Platform';
+
+        return new $adapterClass();
+    }
+
+    /**
+     * Set the migration table name
+     *
+     * @param string $migrationTable
+     */
+    public function setMigrationTable($migrationTable)
+    {
+        $this->migrationTable = $migrationTable;
+    }
+
+    /**
+     * get the migration table name
+     *
+     * @return string
+     */
+    public function getMigrationTable()
+    {
+        return $this->migrationTable;
+    }
+
+    /**
+     * Set the path to the migration classes
+     *
+     * @param string $migrationDir
+     */
+    public function setMigrationDir($migrationDir)
+    {
+        $this->migrationDir = $migrationDir;
+    }
+
+    /**
+     * Get the path to the migration classes
+     *
+     * @return string
+     */
+    public function getMigrationDir()
+    {
+        return $this->migrationDir;
+    }
+
+    /**
+     * @return array[]
+     */
+    public function getExecutedMigrationNames()
+    {
+        if (!$connections = $this->getConnections()) {
+            throw new Exception('You must define database connection settings in a buildtime-conf.xml file to use migrations');
+        }
+
+        $migrationNames = [];
+
+        foreach ($connections as $name => $params) {
+            $pdo = $this->getPdoConnection($name);
+            $sql = sprintf('SELECT migration FROM %s', $this->getMigrationTable());
+
+            try {
+                $stmt = $pdo->prepare($sql);
+                $stmt->execute();
+                while ($migrationName = $stmt->fetchColumn()) {
+                    $migrationNames[] = $migrationName;
+                }
+            } catch (PDOException $e) {
+                $this->createMigrationTable($name);
+            }
+        }
+
+        return $migrationNames;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExecutedMigrationNamesForBatch($batch)
+    {
+        if (!$connections = $this->getConnections()) {
+            throw new Exception('You must define database connection settings in a buildtime-conf.xml file to use migrations');
+        }
+
+        $migrationNames = [];
+
+        foreach ($connections as $name => $params) {
+            $pdo = $this->getPdoConnection($name);
+            $sql = sprintf('SELECT migration FROM %s WHERE batch = %s', $this->getMigrationTable(), $batch);
+
+            try {
+                $stmt = $pdo->prepare($sql);
+                $stmt->execute();
+                while ($migrationName = $stmt->fetchColumn()) {
+                    $migrationNames[] = $migrationName;
+                }
+            } catch (PDOException $e) {
+                $this->createMigrationTable($name);
+            }
+        }
+
+        return $migrationNames;
+    }
+
+    public function migrationTableExists($datasource)
+    {
+        $pdo = $this->getPdoConnection($datasource);
+        $sql = sprintf('SELECT migration FROM %s', $this->getMigrationTable());
+        $stmt = $pdo->prepare($sql);
+        try {
+            $stmt->execute();
+
+            return true;
+        } catch (PDOException $e) {
+            return false;
+        }
+    }
+
+    public function createMigrationTable($datasource)
+    {
+        $platform = $this->getPlatform($datasource);
+        // modelize the table
+        $database = new Database($datasource);
+        $database->setPlatform($platform);
+        $table = new Table($this->getMigrationTable());
+        $database->addTable($table);
+        // add "migration" column
+        $column = new Column('migration');
+        $column->getDomain()->copy($platform->getDomainForType('VARCHAR'));
+        $column->setNotNull(true);
+        $column->setPrimaryKey(true);
+        $table->addColumn($column);
+        // add "batch" column
+        $column = new Column('batch');
+        $column->getDomain()->copy($platform->getDomainForType('INTEGER'));
+        $column->setNotNull(true);
+        $table->addColumn($column);
+        // insert the table into the database
+        $statements = $platform->getAddTableDDL($table);
+        $pdo = $this->getPdoConnection($datasource);
+        $res = PropelSQLParser::executeString($statements, $pdo);
+        if (!$res) {
+            throw new Exception(sprintf('Unable to create migration table in datasource "%s"', $datasource));
+        }
+    }
+
+    public function addExecutedMigration($datasource, $migrationName, $batch)
+    {
+        $platform = $this->getPlatform($datasource);
+        $pdo = $this->getPdoConnection($datasource);
+        $sql = sprintf('INSERT INTO %s (%s, %s) VALUES (?, ?)',
+            $this->getMigrationTable(),
+            $platform->quoteIdentifier('migration'),
+            $platform->quoteIdentifier('batch')
+        );
+        $stmt = $pdo->prepare($sql);
+        $stmt->bindParam(1, $migrationName, PDO::PARAM_STR);
+        $stmt->bindParam(2, $batch, PDO::PARAM_INT);
+        $stmt->execute();
+    }
+
+    public function removeExecutedMigration($datasource, $migrationName)
+    {
+        $platform = $this->getPlatform($datasource);
+        $pdo = $this->getPdoConnection($datasource);
+        $sql = sprintf('DELETE FROM %s WHERE %s = ?',
+            $this->getMigrationTable(),
+            $platform->quoteIdentifier('migration')
+        );
+        $stmt = $pdo->prepare($sql);
+        $stmt->bindParam(1, $migrationName, PDO::PARAM_STR);
+        $stmt->execute();
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExistingMigrationNames()
+    {
+        $path = $this->getMigrationDir();
+        $migrationNames = array();
+
+        if (is_dir($path)) {
+            $files = scandir($path);
+            foreach ($files as $file) {
+                if (preg_match('/^PropelMigration_(\d+)\.php$/', $file, $matches)) {
+                    $migrationNames[] = trim($file, '.php');
+                }
+            }
+        }
+
+        return $migrationNames;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getMissingMigrationNames()
+    {
+        return array_diff($this->getExistingMigrationNames(), $this->getExecutedMigrationNames());
+    }
+
+    /**
+     * @return int
+     */
+    public function getLatestBatch()
+    {
+        if (!$connections = $this->getConnections()) {
+            throw new Exception('You must define database connection settings in a buildtime-conf.xml file to use migrations');
+        }
+
+        $batch = 0;
+
+        foreach ($connections as $name => $params) {
+            $pdo = $this->getPdoConnection($name);
+            $sql = sprintf('SELECT MAX(batch) as latest_batch FROM %s', $this->getMigrationTable());
+
+            try {
+                $stmt = $pdo->prepare($sql);
+                $stmt->execute();
+                if ($datasourceMaxBatch = $stmt->fetchColumn()) {
+                    $batch = $datasourceMaxBatch > $batch ? $datasourceMaxBatch : $batch;
+                }
+            } catch (PDOException $e) {
+                $this->createMigrationTable($name);
+            }
+        }
+
+        return $batch;
+    }
+
+    public function hasPendingMigrations()
+    {
+        return ! empty($this->getMissingMigrationNames());
+    }
+
+    public static function generateMigrationClassName($timestamp)
+    {
+        return sprintf('PropelMigration_%d', $timestamp);
+    }
+
+    public function getMigrationObject($migrationName)
+    {
+        require_once sprintf('%s/%s.php',
+            $this->getMigrationDir(),
+            $migrationName
+        );
+
+        return new $migrationName();
+    }
+
+    public function generateMigrationClassBody($migrationsUp, $migrationsDown, $timestamp)
+    {
+        $timeInWords = date('Y-m-d H:i:s', $timestamp);
+        $migrationAuthor = ($author = $this->getUser()) ? 'by ' . $author : '';
+        $migrationClassName = $this->generateMigrationClassName($timestamp);
+        $migrationUpString = var_export($migrationsUp, true);
+        $migrationDownString = var_export($migrationsDown, true);
+        $migrationClassBody = <<<EOP
+<?php
+
+/**
+ * Data object containing the SQL and PHP code to migrate the database
+ * up to version $timestamp.
+ * Generated on $timeInWords $migrationAuthor
+ */
+class $migrationClassName
+{
+
+    public function preUp(\$manager)
+    {
+        // add the pre-migration code here
+    }
+
+    public function postUp(\$manager)
+    {
+        // add the post-migration code here
+    }
+
+    public function preDown(\$manager)
+    {
+        // add the pre-migration code here
+    }
+
+    public function postDown(\$manager)
+    {
+        // add the post-migration code here
+    }
+
+    /**
+     * Get the SQL statements for the Up migration
+     *
+     * @return array list of the SQL strings to execute for the Up migration
+     *               the keys being the datasources
+     */
+    public function getUpSQL()
+    {
+        return $migrationUpString;
+    }
+
+    /**
+     * Get the SQL statements for the Down migration
+     *
+     * @return array list of the SQL strings to execute for the Down migration
+     *               the keys being the datasources
+     */
+    public function getDownSQL()
+    {
+        return $migrationDownString;
+    }
+
+}
+EOP;
+
+        return $migrationClassBody;
+    }
+
+    public static function generateMigrationFileName($timestamp)
+    {
+        return sprintf('%s.php', self::generateMigrationClassName($timestamp));
+    }
+
+    public static function getUser()
+    {
+        if (function_exists('posix_getuid')) {
+            $currentUser = posix_getpwuid(posix_getuid());
+            if (isset($currentUser['name'])) {
+                return $currentUser['name'];
+            }
+        }
+
+        return '';
+    }
+}

--- a/lib/util/sfPropelMigrationManager.php
+++ b/lib/util/sfPropelMigrationManager.php
@@ -17,319 +17,319 @@
  */
 class sfPropelMigrationManager
 {
-    protected $connections;
-    protected $pdoConnections = array();
-    protected $migrationTable = 'propel_migration';
-    protected $migrationDir;
-    protected $migrationDatabase = 'default';
+  protected $connections;
+  protected $pdoConnections = array();
+  protected $migrationTable = 'propel_migration';
+  protected $migrationDir;
+  protected $migrationDatabase = 'default';
 
-    public function __construct()
-    {
-        $this->migrationDatabase = sfConfig::get('sf_migration_database');
+  public function __construct()
+  {
+    $this->migrationDatabase = sfConfig::get('sf_migration_database');
+  }
+
+  /**
+   * Set the database connection settings
+   *
+   * @param array $connections
+   */
+  public function setConnections($connections)
+  {
+    $this->connections = $connections;
+  }
+
+  /**
+   * Get the database connection settings
+   *
+   * @return array
+   */
+  public function getConnections()
+  {
+    return $this->connections;
+  }
+
+  public function getConnection($datasource)
+  {
+    if (!isset($this->connections[$datasource])) {
+      throw new InvalidArgumentException(sprintf('Unknown datasource "%s"', $datasource));
     }
 
-    /**
-     * Set the database connection settings
-     *
-     * @param array $connections
-     */
-    public function setConnections($connections)
-    {
-        $this->connections = $connections;
+    return $this->connections[$datasource];
+  }
+
+  public function getPdoConnection($datasource)
+  {
+    if (!isset($this->pdoConnections[$datasource])) {
+      $buildConnection = $this->getConnection($datasource);
+      $buildConnection['dsn'] = str_replace("@DB@", $datasource, $buildConnection['dsn']);
+
+      $this->pdoConnections[$datasource] = Propel::initConnection($buildConnection, $datasource);
     }
 
-    /**
-     * Get the database connection settings
-     *
-     * @return array
-     */
-    public function getConnections()
-    {
-        return $this->connections;
+    return $this->pdoConnections[$datasource];
+  }
+
+  public function getPlatform($datasource)
+  {
+    $params = $this->getConnection($datasource);
+    $adapter = $params['adapter'];
+    $adapterClass = ucfirst($adapter) . 'Platform';
+
+    return new $adapterClass();
+  }
+
+  /**
+   * Set the migration table name
+   *
+   * @param string $migrationTable
+   */
+  public function setMigrationTable($migrationTable)
+  {
+    $this->migrationTable = $migrationTable;
+  }
+
+  /**
+   * get the migration table name
+   *
+   * @return string
+   */
+  public function getMigrationTable()
+  {
+    return $this->migrationTable;
+  }
+
+  /**
+   * Set the path to the migration classes
+   *
+   * @param string $migrationDir
+   */
+  public function setMigrationDir($migrationDir)
+  {
+    $this->migrationDir = $migrationDir;
+  }
+
+  /**
+   * Get the path to the migration classes
+   *
+   * @return string
+   */
+  public function getMigrationDir()
+  {
+    return $this->migrationDir;
+  }
+
+  /**
+   * @return string
+   */
+  public function getMigrationDatabase(): string
+  {
+    return $this->migrationDatabase;
+  }
+
+  /**
+   * @param string $migrationDatabase
+   */
+  public function setMigrationDatabase(string $migrationDatabase): void
+  {
+    $this->migrationDatabase = $migrationDatabase;
+  }
+
+  /**
+   * @return string[]
+   */
+  public function getExecutedMigrationNames()
+  {
+    $connections = $this->getConnections();
+
+    if (!isset($connections[$this->migrationDatabase])) {
+      throw new Exception('Provided migration database does not exist');
     }
 
-    public function getConnection($datasource)
-    {
-        if (!isset($this->connections[$datasource])) {
-            throw new InvalidArgumentException(sprintf('Unknown datasource "%s"', $datasource));
+    $migrationNames = [];
+
+    $pdo = $this->getPdoConnection($this->migrationDatabase);
+    $sql = sprintf('SELECT migration FROM %s', $this->getMigrationTable());
+
+    try {
+      $stmt = $pdo->prepare($sql);
+      $stmt->execute();
+
+      while ($migrationName = $stmt->fetchColumn()) {
+        $migrationNames[] = $migrationName;
+      }
+    } catch (PDOException $e) {
+      $this->createMigrationTable();
+    }
+
+    return array_unique($migrationNames);
+  }
+
+  /**
+   * @return string
+   */
+  public function getLatestExecutedMigrationName()
+  {
+    $connections = $this->getConnections();
+
+    if (!isset($connections[$this->migrationDatabase])) {
+      throw new Exception('Provided migration database does not exist');
+    }
+
+    $migrationName = null;
+
+    $pdo = $this->getPdoConnection($this->migrationDatabase);
+    $sql = sprintf('SELECT migration FROM %s ORDER BY id DESC LIMIT 1', $this->getMigrationTable());
+
+    try {
+      $stmt = $pdo->prepare($sql);
+      $stmt->execute();
+
+      $migrationName = $stmt->fetchColumn();
+    } catch (PDOException $e) {
+      $this->createMigrationTable();
+    }
+
+    return $migrationName;
+  }
+
+  /**
+   * @return bool
+   */
+  public function migrationTableExists()
+  {
+    $pdo = $this->getPdoConnection($this->migrationDatabase);
+    $sql = sprintf('SELECT migration FROM %s', $this->getMigrationTable());
+
+    $stmt = $pdo->prepare($sql);
+
+    try {
+      $stmt->execute();
+    } catch (PDOException $e) {
+      return false;
+    }
+
+    return true;
+  }
+
+  public function createMigrationTable()
+  {
+    $connections = $this->getConnections();
+
+    if (!isset($connections[$this->migrationDatabase])) {
+      throw new Exception('Provided migration database does not exist');
+    }
+
+    $platform = $this->getPlatform($this->migrationDatabase);
+
+    $database = new Database($this->migrationDatabase);
+    $database->setPlatform($platform);
+
+    $table = new Table($this->getMigrationTable());
+    $table->setIdMethod('native');
+    $database->addTable($table);
+
+    $column = new Column('id');
+    $column->getDomain()->copy($platform->getDomainForType('INTEGER'));
+    $column->setNotNull(true);
+    $column->setPrimaryKey(true);
+    $column->setAutoIncrement(true);
+    $table->addColumn($column);
+
+    $column = new Column('migration');
+    $column->getDomain()->copy($platform->getDomainForType('VARCHAR'));
+    $column->setNotNull(true);
+    $column->setUnique(true);
+    $table->addColumn($column);
+
+    $statements = $platform->getAddTableDDL($table);
+    $pdo = $this->getPdoConnection($this->migrationDatabase);
+    $res = PropelSQLParser::executeString($statements, $pdo);
+
+    if (!$res) {
+      throw new Exception(sprintf('Unable to create migration table in datasource "%s"', $this->migrationDatabase));
+    }
+  }
+
+  public function addExecutedMigration($migrationName)
+  {
+    $platform = $this->getPlatform($this->migrationDatabase);
+    $pdo = $this->getPdoConnection($this->migrationDatabase);
+    $sql = sprintf('INSERT INTO %s (%s) VALUES (?)',
+      $this->getMigrationTable(),
+      $platform->quoteIdentifier('migration'),
+    );
+    $stmt = $pdo->prepare($sql);
+    $stmt->bindParam(1, $migrationName, PDO::PARAM_STR);
+    $stmt->execute();
+  }
+
+  public function removeExecutedMigration($migrationName)
+  {
+    $platform = $this->getPlatform($this->migrationDatabase);
+    $pdo = $this->getPdoConnection($this->migrationDatabase);
+    $sql = sprintf('DELETE FROM %s WHERE %s = ?',
+      $this->getMigrationTable(),
+      $platform->quoteIdentifier('migration')
+    );
+    $stmt = $pdo->prepare($sql);
+    $stmt->bindParam(1, $migrationName, PDO::PARAM_STR);
+    $stmt->execute();
+  }
+
+  /**
+   * @return string[]
+   */
+  public function getExistingMigrationNames()
+  {
+    $path = $this->getMigrationDir();
+
+    $migrationNames = array();
+
+    if (is_dir($path)) {
+      foreach (scandir($path) as $file) {
+        if (preg_match('/^PropelMigration_(\d+)\.php$/', $file, $matches)) {
+          $migrationNames[] = trim($file, '.php');
         }
-
-        return $this->connections[$datasource];
+      }
     }
 
-    public function getPdoConnection($datasource)
-    {
-        if (!isset($this->pdoConnections[$datasource])) {
-            $buildConnection = $this->getConnection($datasource);
-            $buildConnection['dsn'] = str_replace("@DB@", $datasource, $buildConnection['dsn']);
+    return $migrationNames;
+  }
 
-            $this->pdoConnections[$datasource] = Propel::initConnection($buildConnection, $datasource);
-        }
+  /**
+   * @return string[]
+   */
+  public function getMissingMigrationNames()
+  {
+    return array_diff($this->getExistingMigrationNames(), $this->getExecutedMigrationNames());
+  }
 
-        return $this->pdoConnections[$datasource];
-    }
+  /**
+   * @return string
+   */
+  public static function generateMigrationClassName($timestamp)
+  {
+    return sprintf('PropelMigration_%d', $timestamp);
+  }
 
-    public function getPlatform($datasource)
-    {
-        $params = $this->getConnection($datasource);
-        $adapter = $params['adapter'];
-        $adapterClass = ucfirst($adapter) . 'Platform';
+  public function getMigrationObject($migrationName)
+  {
+    require_once sprintf('%s/%s.php',
+      $this->getMigrationDir(),
+      $migrationName
+    );
 
-        return new $adapterClass();
-    }
+    return new $migrationName();
+  }
 
-    /**
-     * Set the migration table name
-     *
-     * @param string $migrationTable
-     */
-    public function setMigrationTable($migrationTable)
-    {
-        $this->migrationTable = $migrationTable;
-    }
-
-    /**
-     * get the migration table name
-     *
-     * @return string
-     */
-    public function getMigrationTable()
-    {
-        return $this->migrationTable;
-    }
-
-    /**
-     * Set the path to the migration classes
-     *
-     * @param string $migrationDir
-     */
-    public function setMigrationDir($migrationDir)
-    {
-        $this->migrationDir = $migrationDir;
-    }
-
-    /**
-     * Get the path to the migration classes
-     *
-     * @return string
-     */
-    public function getMigrationDir()
-    {
-        return $this->migrationDir;
-    }
-
-    /**
-     * @return string
-     */
-    public function getMigrationDatabase(): string
-    {
-        return $this->migrationDatabase;
-    }
-
-    /**
-     * @param string $migrationDatabase
-     */
-    public function setMigrationDatabase(string $migrationDatabase): void
-    {
-        $this->migrationDatabase = $migrationDatabase;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getExecutedMigrationNames()
-    {
-        $connections = $this->getConnections();
-
-        if (!isset($connections[$this->migrationDatabase])) {
-            throw new Exception('Provided migration database does not exist');
-        }
-
-        $migrationNames = [];
-
-        $pdo = $this->getPdoConnection($this->migrationDatabase);
-        $sql = sprintf('SELECT migration FROM %s', $this->getMigrationTable());
-
-        try {
-            $stmt = $pdo->prepare($sql);
-            $stmt->execute();
-
-            while ($migrationName = $stmt->fetchColumn()) {
-                $migrationNames[] = $migrationName;
-            }
-        } catch (PDOException $e) {
-            $this->createMigrationTable();
-        }
-
-        return array_unique($migrationNames);
-    }
-
-    /**
-     * @return string
-     */
-    public function getLatestExecutedMigrationName()
-    {
-        $connections = $this->getConnections();
-
-        if (!isset($connections[$this->migrationDatabase])) {
-            throw new Exception('Provided migration database does not exist');
-        }
-
-        $migrationName = null;
-
-        $pdo = $this->getPdoConnection($this->migrationDatabase);
-        $sql = sprintf('SELECT migration FROM %s ORDER BY id DESC LIMIT 1', $this->getMigrationTable());
-
-        try {
-            $stmt = $pdo->prepare($sql);
-            $stmt->execute();
-
-            $migrationName = $stmt->fetchColumn();
-        } catch (PDOException $e) {
-            $this->createMigrationTable();
-        }
-
-        return $migrationName;
-    }
-
-    /**
-     * @return bool
-     */
-    public function migrationTableExists()
-    {
-        $pdo = $this->getPdoConnection($this->migrationDatabase);
-        $sql = sprintf('SELECT migration FROM %s', $this->getMigrationTable());
-
-        $stmt = $pdo->prepare($sql);
-
-        try {
-            $stmt->execute();
-        } catch (PDOException $e) {
-            return false;
-        }
-
-        return true;
-    }
-
-    public function createMigrationTable()
-    {
-        $connections = $this->getConnections();
-
-        if (!isset($connections[$this->migrationDatabase])) {
-            throw new Exception('Provided migration database does not exist');
-        }
-
-        $platform = $this->getPlatform($this->migrationDatabase);
-
-        $database = new Database($this->migrationDatabase);
-        $database->setPlatform($platform);
-
-        $table = new Table($this->getMigrationTable());
-        $table->setIdMethod('native');
-        $database->addTable($table);
-
-        $column = new Column('id');
-        $column->getDomain()->copy($platform->getDomainForType('INTEGER'));
-        $column->setNotNull(true);
-        $column->setPrimaryKey(true);
-        $column->setAutoIncrement(true);
-        $table->addColumn($column);
-
-        $column = new Column('migration');
-        $column->getDomain()->copy($platform->getDomainForType('VARCHAR'));
-        $column->setNotNull(true);
-        $column->setUnique(true);
-        $table->addColumn($column);
-
-        $statements = $platform->getAddTableDDL($table);
-        $pdo = $this->getPdoConnection($this->migrationDatabase);
-        $res = PropelSQLParser::executeString($statements, $pdo);
-
-        if (!$res) {
-            throw new Exception(sprintf('Unable to create migration table in datasource "%s"', $this->migrationDatabase));
-        }
-    }
-
-    public function addExecutedMigration($migrationName)
-    {
-        $platform = $this->getPlatform($this->migrationDatabase);
-        $pdo = $this->getPdoConnection($this->migrationDatabase);
-        $sql = sprintf('INSERT INTO %s (%s) VALUES (?)',
-            $this->getMigrationTable(),
-            $platform->quoteIdentifier('migration'),
-        );
-        $stmt = $pdo->prepare($sql);
-        $stmt->bindParam(1, $migrationName, PDO::PARAM_STR);
-        $stmt->execute();
-    }
-
-    public function removeExecutedMigration($migrationName)
-    {
-        $platform = $this->getPlatform($this->migrationDatabase);
-        $pdo = $this->getPdoConnection($this->migrationDatabase);
-        $sql = sprintf('DELETE FROM %s WHERE %s = ?',
-            $this->getMigrationTable(),
-            $platform->quoteIdentifier('migration')
-        );
-        $stmt = $pdo->prepare($sql);
-        $stmt->bindParam(1, $migrationName, PDO::PARAM_STR);
-        $stmt->execute();
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getExistingMigrationNames()
-    {
-        $path = $this->getMigrationDir();
-
-        $migrationNames = array();
-
-        if (is_dir($path)) {
-            foreach (scandir($path) as $file) {
-                if (preg_match('/^PropelMigration_(\d+)\.php$/', $file, $matches)) {
-                    $migrationNames[] = trim($file, '.php');
-                }
-            }
-        }
-
-        return $migrationNames;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getMissingMigrationNames()
-    {
-        return array_diff($this->getExistingMigrationNames(), $this->getExecutedMigrationNames());
-    }
-
-    /**
-     * @return string
-     */
-    public static function generateMigrationClassName($timestamp)
-    {
-        return sprintf('PropelMigration_%d', $timestamp);
-    }
-
-    public function getMigrationObject($migrationName)
-    {
-        require_once sprintf('%s/%s.php',
-            $this->getMigrationDir(),
-            $migrationName
-        );
-
-        return new $migrationName();
-    }
-
-    public function generateMigrationClassBody($migrationsUp, $migrationsDown, $timestamp)
-    {
-        $timeInWords = date('Y-m-d H:i:s', $timestamp);
-        $migrationAuthor = ($author = $this->getUser()) ? 'by ' . $author : '';
-        $migrationClassName = $this->generateMigrationClassName($timestamp);
-        $migrationUpString = var_export($migrationsUp, true);
-        $migrationDownString = var_export($migrationsDown, true);
-        $migrationClassBody = <<<EOP
+  public function generateMigrationClassBody($migrationsUp, $migrationsDown, $timestamp)
+  {
+    $timeInWords = date('Y-m-d H:i:s', $timestamp);
+    $migrationAuthor = ($author = $this->getUser()) ? 'by ' . $author : '';
+    $migrationClassName = $this->generateMigrationClassName($timestamp);
+    $migrationUpString = var_export($migrationsUp, true);
+    $migrationDownString = var_export($migrationsDown, true);
+    $migrationClassBody = <<<EOP
 <?php
 
 /**
@@ -385,23 +385,23 @@ class $migrationClassName
 }
 EOP;
 
-        return $migrationClassBody;
+    return $migrationClassBody;
+  }
+
+  public function generateMigrationFileName($timestamp)
+  {
+    return sprintf('%s.php', self::generateMigrationClassName($timestamp));
+  }
+
+  public function getUser()
+  {
+    if (function_exists('posix_getuid')) {
+      $currentUser = posix_getpwuid(posix_getuid());
+      if (isset($currentUser['name'])) {
+        return $currentUser['name'];
+      }
     }
 
-    public function generateMigrationFileName($timestamp)
-    {
-        return sprintf('%s.php', self::generateMigrationClassName($timestamp));
-    }
-
-    public function getUser()
-    {
-        if (function_exists('posix_getuid')) {
-            $currentUser = posix_getpwuid(posix_getuid());
-            if (isset($currentUser['name'])) {
-                return $currentUser['name'];
-            }
-        }
-
-        return '';
-    }
+    return '';
+  }
 }


### PR DESCRIPTION
These changes/improvements are in order to prevent shadowing migrations.

**SOLUTION:**

Store all executed migrations in table `migration` that has following columns:
- `id` - auto-increment integer
- `migration`  - unique string, holds name of the executed migration

Implemented following class:
- `sfPropelMigrationManager` - replacement for original `PropelMigrationManager`.

Reimplemented following tasks to use the new `sfPropelMigrationManager`:
- `propel:status` - it now compares filenames from migration directory with names from `migration` table.
- `propel:migrate` - it now gets all filenames that are missing from `migration` table, and executes them one by one. Writes a record to `migration` table after each successful migration execution (no transactions).
- `propel:up` - gets next migration file from migrations directory that is not recorded in `migration` table and executes it.
- `propel:down` - gets latest executed migration from `migration` table (the one that has `MAX(id)`), and executes the `down` SQL on it, then removes the record from `migration` table.

 